### PR TITLE
MultipleContentBuilder new-line fix

### DIFF
--- a/TextTemplateTransformationFramework.sln
+++ b/TextTemplateTransformationFramework.sln
@@ -36,6 +36,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TextTemplateTransformationFramework.Common.Cmd.Tests", "src\Common.Cmd.Tests\TextTemplateTransformationFramework.Common.Cmd.Tests.csproj", "{DAEC2AE5-F423-4846-9EE2-8C8DE774498B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TextTemplateTransformationFramework.Runtime.Tests", "src\Runtime.Tests\TextTemplateTransformationFramework.Runtime.Tests.csproj", "{AB53CD8C-800F-4528-AF6B-4A39B46DAB2F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -98,6 +100,10 @@ Global
 		{DAEC2AE5-F423-4846-9EE2-8C8DE774498B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DAEC2AE5-F423-4846-9EE2-8C8DE774498B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DAEC2AE5-F423-4846-9EE2-8C8DE774498B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB53CD8C-800F-4528-AF6B-4A39B46DAB2F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB53CD8C-800F-4528-AF6B-4A39B46DAB2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB53CD8C-800F-4528-AF6B-4A39B46DAB2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB53CD8C-800F-4528-AF6B-4A39B46DAB2F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Runtime.Tests/MultipleContentBuilderTests.cs
+++ b/src/Runtime.Tests/MultipleContentBuilderTests.cs
@@ -1,0 +1,32 @@
+﻿using System.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace TextTemplateTransformationFramework.Runtime.Tests
+{
+    public class MultipleContentBuilderTests
+    {
+        [Fact]
+        public void SaveAll_Saves_All_Contents()
+        {
+            // Arrange
+            var basePath = Path.Combine(Path.GetTempPath(), nameof(SaveAll_Saves_All_Contents));
+            if (Directory.Exists(basePath))
+            {
+                Directory.Delete(basePath, true);
+            }
+            var sut = new MultipleContentBuilder(basePath);
+            var c1 = sut.AddContent("File1.txt");
+            c1.Builder.AppendLine("Test1");
+            var c2 = sut.AddContent("File2.txt");
+            c2.Builder.AppendLine("Test2");
+
+            // Act
+            sut.SaveAll();
+
+            // Assert
+            File.Exists(Path.Combine(basePath, "File1.txt")).Should().BeTrue();
+            File.Exists(Path.Combine(basePath, "File2.txt")).Should().BeTrue();
+        }
+    }
+}

--- a/src/Runtime.Tests/TemplateRenderHelperTests.cs
+++ b/src/Runtime.Tests/TemplateRenderHelperTests.cs
@@ -4,10 +4,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using FluentAssertions;
-using TextTemplateTransformationFramework.Runtime;
 using Xunit;
 
-namespace TextTemplateTransformationFramework.T4.Plus.Tests
+namespace TextTemplateTransformationFramework.Runtime.Tests
 {
     [ExcludeFromCodeCoverage]
     public class TemplateRenderHelperTests

--- a/src/Runtime.Tests/TextTemplateTransformationFramework.Runtime.Tests.csproj
+++ b/src/Runtime.Tests/TextTemplateTransformationFramework.Runtime.Tests.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <DebugType>Full</DebugType>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.3" />
+    <PackageReference Include="pauldeen79.CrossCutting.Utilities.ObjectDumper" Version="2.7.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Runtime\TextTemplateTransformationFramework.Runtime.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Runtime/Extensions/StringExtensions.cs
+++ b/src/Runtime/Extensions/StringExtensions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace TextTemplateTransformationFramework.Runtime.Extensions
+{
+    public static class StringExtensions
+    {
+        public static string NormalizeLineEndings(this string instance)
+            => Regex.Replace(instance, @"\r\n|\n\r|\n|\r", Environment.NewLine);
+    }
+}

--- a/src/Runtime/MultipleContentBuilder.cs
+++ b/src/Runtime/MultipleContentBuilder.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Xml;
+using TextTemplateTransformationFramework.Runtime.Extensions;
 
 namespace TextTemplateTransformationFramework.Runtime
 {
@@ -34,7 +35,7 @@ namespace TextTemplateTransformationFramework.Runtime
                     Directory.CreateDirectory(dir);
                 }
 
-                var contents = content.Builder.ToString();
+                var contents = content.Builder.ToString().NormalizeLineEndings();
                 File.WriteAllText(path, contents, Encoding.UTF8);
             }
         }
@@ -114,7 +115,7 @@ namespace TextTemplateTransformationFramework.Runtime
                 Contents = _contentList.Select(c => new Contents
                 {
                     FileName = c.FileName,
-                    Lines = c.Builder.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None).ToList(),
+                    Lines = c.Builder.ToString().NormalizeLineEndings().Split(new[] { Environment.NewLine }, StringSplitOptions.None).ToList(),
                     SkipWhenFileExists = c.SkipWhenFileExists
                 }).ToList()
             };
@@ -173,6 +174,5 @@ namespace TextTemplateTransformationFramework.Runtime
             => recurse
                 ? SearchOption.AllDirectories
                 : SearchOption.TopDirectoryOnly;
-
     }
 }


### PR DESCRIPTION
Fixed problem with MultipleContentBuilder on templates generated on a different OS, where newlines would get mixed up.

For example, if you use a generator from a nuget package that's build on Linux, and you consume this package on Windows, then the contents in MultipleContentBuilder did not recognize the newlines correctly. This has now been fixed, by normalizing newlines before writing the contents to file, or converting the lines to an xml string.