### PR TITLE
Add support for global templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,17 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 

--- a/.sonarlint/TextTemplateTransformationFramework.slconfig
+++ b/.sonarlint/TextTemplateTransformationFramework.slconfig
@@ -9,7 +9,7 @@
   "Profiles": {
     "CSharp": {
       "ProfileKey": "AXhZfo6en_M4LyoxHL-X",
-      "ProfileTimestamp": "2023-04-20T10:52:15Z"
+      "ProfileTimestamp": "2023-05-31T14:52:04Z"
     },
     "Secrets": {
       "ProfileKey": "AYXoTKjH9Ao2yLWbNFAw",

--- a/.sonarlint/TextTemplateTransformationFramework.slconfig
+++ b/.sonarlint/TextTemplateTransformationFramework.slconfig
@@ -9,7 +9,7 @@
   "Profiles": {
     "CSharp": {
       "ProfileKey": "AXhZfo6en_M4LyoxHL-X",
-      "ProfileTimestamp": "2023-05-31T14:52:04Z"
+      "ProfileTimestamp": "2023-06-05T13:09:33Z"
     },
     "Secrets": {
       "ProfileKey": "AYXoTKjH9Ao2yLWbNFAw",

--- a/.sonarlint/pauldeen79_texttemplatetransformationframeworkcsharp.ruleset
+++ b/.sonarlint/pauldeen79_texttemplatetransformationframeworkcsharp.ruleset
@@ -382,6 +382,17 @@
     <Rule Id="S6424" Action="Warning" />
     <Rule Id="S6507" Action="None" />
     <Rule Id="S6513" Action="None" />
+    <Rule Id="S6602" Action="Info" />
+    <Rule Id="S6603" Action="Info" />
+    <Rule Id="S6605" Action="Info" />
+    <Rule Id="S6607" Action="Info" />
+    <Rule Id="S6608" Action="Info" />
+    <Rule Id="S6609" Action="Info" />
+    <Rule Id="S6610" Action="Info" />
+    <Rule Id="S6612" Action="Info" />
+    <Rule Id="S6613" Action="Info" />
+    <Rule Id="S6617" Action="Info" />
+    <Rule Id="S6618" Action="Info" />
     <Rule Id="S818" Action="Info" />
     <Rule Id="S881" Action="None" />
     <Rule Id="S907" Action="Warning" />

--- a/.sonarlint/pauldeen79_texttemplatetransformationframeworkcsharp.ruleset
+++ b/.sonarlint/pauldeen79_texttemplatetransformationframeworkcsharp.ruleset
@@ -281,7 +281,7 @@
     <Rule Id="S3927" Action="Warning" />
     <Rule Id="S3928" Action="Warning" />
     <Rule Id="S3937" Action="None" />
-    <Rule Id="S3949" Action="None" />
+    <Rule Id="S3949" Action="Warning" />
     <Rule Id="S3956" Action="None" />
     <Rule Id="S3962" Action="None" />
     <Rule Id="S3963" Action="Info" />

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/T4.Plus.Cmd/bin/Debug/net6.0/TextTemplateTransformationFramework.T4.Plus.Cmd.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/T4.Plus.Cmd",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "dotnet.defaultSolution": "TextTemplateTransformationFramework.sln"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/src/T4.Plus.Cmd/TextTemplateTransformationFramework.T4.Plus.Cmd.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/src/T4.Plus.Cmd/TextTemplateTransformationFramework.T4.Plus.Cmd.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/src/T4.Plus.Cmd/TextTemplateTransformationFramework.T4.Plus.Cmd.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/src/Common.Cmd.Tests/CommandLineCommands/AddTemplateCommandTests.cs
+++ b/src/Common.Cmd.Tests/CommandLineCommands/AddTemplateCommandTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using CrossCutting.Common.Testing;
+using FluentAssertions;
+using McMaster.Extensions.CommandLineUtils;
+using Moq;
+using TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands;
+using TextTemplateTransformationFramework.Common.Cmd.Tests.TestFixtures;
+using TextTemplateTransformationFramework.Common.Contracts;
+using Xunit;
+
+namespace TextTemplateTransformationFramework.Common.Cmd.Tests.CommandLineCommands
+{
+    [ExcludeFromCodeCoverage]
+    public class AddTemplateCommandTests
+    {
+        private readonly Mock<IFileContentsProvider> _fileContentsProviderMock = new();
+        private readonly Mock<ITemplateInfoRepository> _templateInfoRepositoryMock = new();
+
+        [Fact]
+        public void Ctor_Throws_On_Null_Argument()
+        {
+            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(AddTemplateCommand));
+        }
+
+        [Fact]
+        public void Initialize_Adds_VersionCommand_To_Application()
+        {
+            // Arrange
+            var app = new CommandLineApplication();
+            var sut = CreateSut();
+
+            // Act
+            sut.Initialize(app);
+
+            // Assert
+            app.Commands.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void Initialize_Throws_On_Null_Argument()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act & Assert
+            sut.Invoking(x => x.Initialize(null)).Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Execute_Without_ShortName_Leads_To_Error()
+        {
+            // Arrange
+            _fileContentsProviderMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+
+            // Act
+            var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut, "-f my.template");
+
+            // Assert
+            actual.Should().Be("Error: Shortname is required." + Environment.NewLine);
+        }
+
+        [Fact]
+        public void Execute_With_ShortName_And_Filename_Adds_Template_To_Repository()
+        {
+            // Arrange
+            _fileContentsProviderMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+
+            // Act
+            var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut, "-f my.template", "-s mytemplate");
+
+            // Assert
+            actual.Should().Be("Template has been added successfully." + Environment.NewLine);
+            _templateInfoRepositoryMock.Verify(x => x.Add(It.IsAny<TemplateInfo>()), Times.Once);
+        }
+
+        private AddTemplateCommand CreateSut()
+            => new AddTemplateCommand(_fileContentsProviderMock.Object, _templateInfoRepositoryMock.Object);
+    }
+}

--- a/src/Common.Cmd.Tests/CommandLineCommands/AddTemplateCommandTests.cs
+++ b/src/Common.Cmd.Tests/CommandLineCommands/AddTemplateCommandTests.cs
@@ -61,6 +61,58 @@ namespace TextTemplateTransformationFramework.Common.Cmd.Tests.CommandLineComman
         }
 
         [Fact]
+        public void Execute_Without_FileName_And_AssemblyName_Leads_To_Error()
+        {
+            // Arrange
+            _fileContentsProviderMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+
+            // Act
+            var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut, "-s MyShortName");
+
+            // Assert
+            actual.Should().Be("Error: Either Filename or AssemblyName is required." + Environment.NewLine);
+        }
+
+        [Fact]
+        public void Execute_With_Both_FileName_And_AssemblyName_Leads_To_Error()
+        {
+            // Arrange
+            _fileContentsProviderMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+
+            // Act
+            var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut, "-s MyShortName", "-f my.template", "-a my.dll", "-n myclass");
+
+            // Assert
+            actual.Should().Be("Error: You can either use Filename or AssemblyName, not both." + Environment.NewLine);
+        }
+
+        [Fact]
+        public void Execute_With_AssemblyName_But_Without_ClassName_Leads_To_Error()
+        {
+            // Arrange
+            _fileContentsProviderMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+
+            // Act
+            var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut, "-s MyShortName", "-a my.dll");
+
+            // Assert
+            actual.Should().Be("Error: When AssemblyName is filled, then ClassName is required." + Environment.NewLine);
+        }
+
+        [Fact]
+        public void Execute_With_ShortName_And_Filename_Gives_Error_When_File_Does_Not_Exist()
+        {
+            // Arrange
+            _fileContentsProviderMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns(false);
+
+            // Act
+            var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut, "-f my.template", "-s mytemplate");
+
+            // Assert
+            actual.Should().Be("Error: File [my.template] does not exist." + Environment.NewLine);
+        }
+
+        [Fact]
         public void Execute_With_ShortName_And_Filename_Adds_Template_To_Repository()
         {
             // Arrange

--- a/src/Common.Cmd.Tests/CommandLineCommands/ListParametersCommandTests.cs
+++ b/src/Common.Cmd.Tests/CommandLineCommands/ListParametersCommandTests.cs
@@ -17,14 +17,20 @@ namespace TextTemplateTransformationFramework.Common.Cmd.Tests.CommandLineComman
     {
         private readonly Mock<ITextTemplateProcessor> _processorMock;
         private readonly Mock<IFileContentsProvider> _fileContentsProviderMock;
+        private readonly Mock<ITemplateInfoRepository> _templateInfoRepositoryMock;
         private readonly Mock<IAssemblyService> _assemblyServiceMock;
 
-        private ListParametersCommand CreateSut() => new ListParametersCommand(_processorMock.Object, _fileContentsProviderMock.Object, _assemblyServiceMock.Object);
+        private ListParametersCommand CreateSut() => new ListParametersCommand(
+            _processorMock.Object,
+            _fileContentsProviderMock.Object,
+            _templateInfoRepositoryMock.Object,
+            _assemblyServiceMock.Object);
 
         public ListParametersCommandTests()
         {
             _processorMock = new Mock<ITextTemplateProcessor>();
             _fileContentsProviderMock = new Mock<IFileContentsProvider>();
+            _templateInfoRepositoryMock = new Mock<ITemplateInfoRepository>();
             _assemblyServiceMock = new Mock<IAssemblyService>();
         }
 
@@ -65,7 +71,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.Tests.CommandLineComman
             var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut);
 
             // Assert
-            actual.Should().Be("Error: Either Filename or AssemblyName is required." + Environment.NewLine);
+            actual.Should().Be("Error: Either Filename, AssemblyName or ShortName is required." + Environment.NewLine);
         }
 
         [Fact]
@@ -75,7 +81,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.Tests.CommandLineComman
             var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut, "-f existing.template", "-a myassembly.dll");
 
             // Assert
-            actual.Should().Be("Error: You can either use Filename or AssemblyName, not both." + Environment.NewLine);
+            actual.Should().Be("Error: You can either use Filename, AssemblyName or ShortName, not a combination of these." + Environment.NewLine);
         }
 
         [Fact]

--- a/src/Common.Cmd.Tests/CommandLineCommands/ListTemplatesCommandTests.cs
+++ b/src/Common.Cmd.Tests/CommandLineCommands/ListTemplatesCommandTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using CrossCutting.Common.Testing;
+using FluentAssertions;
+using McMaster.Extensions.CommandLineUtils;
+using Moq;
+using TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands;
+using TextTemplateTransformationFramework.Common.Cmd.Tests.TestFixtures;
+using TextTemplateTransformationFramework.Common.Contracts;
+using Xunit;
+
+namespace TextTemplateTransformationFramework.Common.Cmd.Tests.CommandLineCommands
+{
+    [ExcludeFromCodeCoverage]
+    public class ListTemplatesCommandTests
+    {
+        private readonly Mock<ITemplateInfoRepository> _templateInfoRepositoryMock = new();
+
+        [Fact]
+        public void Ctor_Throws_On_Null_Argument()
+        {
+            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(ListTemplatesCommand));
+        }
+
+        [Fact]
+        public void Initialize_Adds_VersionCommand_To_Application()
+        {
+            // Arrange
+            var app = new CommandLineApplication();
+            var sut = CreateSut();
+
+            // Act
+            sut.Initialize(app);
+
+            // Assert
+            app.Commands.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void Initialize_Throws_On_Null_Argument()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act & Assert
+            sut.Invoking(x => x.Initialize(null)).Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Execute_Returns_Data_In_Output()
+        {
+            // Arrange
+            _templateInfoRepositoryMock.Setup(x => x.GetTemplates()).Returns(new[] { new TemplateInfo("ShortName", "FileName.template", string.Empty, string.Empty, TemplateType.TextTemplate, Array.Empty<TemplateParameter>()) });
+
+            // Act
+            var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut);
+
+            // Assert
+            actual.Should().Be("TemplateInfo { ShortName = ShortName, FileName = FileName.template, AssemblyName = , ClassName = , Type = TextTemplate, Parameters = TextTemplateTransformationFramework.Common.TemplateParameter[] }" + Environment.NewLine);
+        }
+
+        private ListTemplatesCommand CreateSut() => new(_templateInfoRepositoryMock.Object);
+    }
+}

--- a/src/Common.Cmd.Tests/CommandLineCommands/RemoveTemplateCommandTests.cs
+++ b/src/Common.Cmd.Tests/CommandLineCommands/RemoveTemplateCommandTests.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using CrossCutting.Common.Testing;
+using FluentAssertions;
+using McMaster.Extensions.CommandLineUtils;
+using Moq;
+using TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands;
+using TextTemplateTransformationFramework.Common.Cmd.Tests.TestFixtures;
+using TextTemplateTransformationFramework.Common.Contracts;
+using Xunit;
+
+namespace TextTemplateTransformationFramework.Common.Cmd.Tests.CommandLineCommands
+{
+    [ExcludeFromCodeCoverage]
+    public class RemoveTemplateCommandTests
+    {
+        private readonly Mock<IFileContentsProvider> _fileContentsProviderMock = new();
+        private readonly Mock<ITemplateInfoRepository> _templateInfoRepositoryMock = new();
+
+        [Fact]
+        public void Ctor_Throws_On_Null_Argument()
+        {
+            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(RemoveTemplateCommand));
+        }
+
+        [Fact]
+        public void Initialize_Adds_VersionCommand_To_Application()
+        {
+            // Arrange
+            var app = new CommandLineApplication();
+            var sut = CreateSut();
+
+            // Act
+            sut.Initialize(app);
+
+            // Assert
+            app.Commands.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void Initialize_Throws_On_Null_Argument()
+        {
+            // Arrange
+            var sut = CreateSut();
+
+            // Act & Assert
+            sut.Invoking(x => x.Initialize(null)).Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Execute_Without_ShortName_Leads_To_Error()
+        {
+            // Arrange
+            _fileContentsProviderMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+
+            // Act
+            var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut, "-f my.template");
+
+            // Assert
+            actual.Should().Be("Error: Shortname is required." + Environment.NewLine);
+        }
+
+        [Fact]
+        public void Execute_With_ShortName_And_Filename_Removes_Template_From_Repository()
+        {
+            // Arrange
+            _fileContentsProviderMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+
+            // Act
+            var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut, "-f my.template", "-s mytemplate");
+
+            // Assert
+            actual.Should().Be("Template has been removed successfully." + Environment.NewLine);
+            _templateInfoRepositoryMock.Verify(x => x.Remove(It.IsAny<TemplateInfo>()), Times.Once);
+        }
+
+        private RemoveTemplateCommand CreateSut()
+            => new RemoveTemplateCommand(_fileContentsProviderMock.Object, _templateInfoRepositoryMock.Object);
+    }
+}

--- a/src/Common.Cmd.Tests/CommandLineCommands/RunTemplateCommandTests.cs
+++ b/src/Common.Cmd.Tests/CommandLineCommands/RunTemplateCommandTests.cs
@@ -322,6 +322,23 @@ template output
         }
 
         [Fact]
+        public void Execute_Global_Template_With_Parameters_Merges_Parameters_Correctly()
+        {
+            // Arrange
+            _fileContentsProviderMock.Setup(x => x.FileExists("existing.template")).Returns(true);
+            _fileContentsProviderMock.Setup(x => x.GetFileContents("existing.template")).Returns("<#@ template language=\"c#\" #>");
+            _templateInfoRepositoryMock.Setup(x => x.FindByShortName(It.IsAny<string>())).Returns(new TemplateInfo("myshortname", "existing.template", "", "", TemplateType.TextTemplate, new[] { new TemplateParameter { Name = "param1", Value = "defaultValue" } }));
+            _processorMock.Setup(x => x.Process(It.IsAny<TextTemplate>(), It.IsAny<TemplateParameter[]>()))
+                          .Returns(ProcessResult.Create(Array.Empty<CompilerError>(), "template output"));
+
+            // Act
+            _ = CommandLineCommandHelper.ExecuteCommand(CreateSut, "-s myshortname", "param1:value1", "param2:value2");
+
+            // Assert
+            _processorMock.Verify(x => x.Process(It.IsAny<TextTemplate>(), It.Is<TemplateParameter[]>(x => x.Length == 2 && x.First().Name == "param1" && x.First().Value.ToString() == "value1" && x.Last().Name == "param2" && x.Last().Value.ToString() == "value2")));
+        }
+
+        [Fact]
         public void Execute_Interactive_Gets_Parameters_Correctly()
         {
             // Arrange

--- a/src/Common.Cmd.Tests/CommandLineCommands/RunTemplateCommandTests.cs
+++ b/src/Common.Cmd.Tests/CommandLineCommands/RunTemplateCommandTests.cs
@@ -239,6 +239,17 @@ template output
         }
 
         [Fact]
+        public void Execute_With_Non_Existing_Short_Name_Gives_Exception()
+        {
+            var actual = CommandLineCommandHelper.ExecuteCommand(CreateSut, "-s myshortname");
+
+            // Assert
+            actual.Should().Be(@"Exception occured while processing the template:
+System.InvalidOperationException: Could not find template with short name myshortname
+");
+        }
+
+        [Fact]
         public void Execute_With_Output_Option_Saves_Output_To_File()
         {
             // Arrange

--- a/src/Common.Cmd.Tests/CommandLineCommands/SourceCodeCommandTests.cs
+++ b/src/Common.Cmd.Tests/CommandLineCommands/SourceCodeCommandTests.cs
@@ -6,7 +6,6 @@ using McMaster.Extensions.CommandLineUtils;
 using Moq;
 using TextCopy;
 using TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands;
-using TextTemplateTransformationFramework.Common.Cmd.Contracts;
 using TextTemplateTransformationFramework.Common.Cmd.Tests.TestFixtures;
 using TextTemplateTransformationFramework.Common.Contracts;
 using Xunit;

--- a/src/Common.Cmd.Tests/Default/UserInputTests.cs
+++ b/src/Common.Cmd.Tests/Default/UserInputTests.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using TextTemplateTransformationFramework.Common.Cmd.Default;
+using Xunit;
+
+namespace TextTemplateTransformationFramework.Common.Cmd.Tests.Default
+{
+    [ExcludeFromCodeCoverage]
+    public class UserInputTests
+    {
+        [Fact]        
+        public void UserInput_Throws_On_Null_Argument()
+        {
+            // Arrange
+            var sut = new UserInput();
+
+            // Act & Assert
+            sut.Invoking(x => x.GetValue(null)).Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/src/Common.Cmd.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/src/Common.Cmd.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -4,7 +4,6 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using ScriptCompiler;
-using TextTemplateTransformationFramework.Common.Cmd.Contracts;
 using TextTemplateTransformationFramework.Common.Cmd.Extensions;
 using TextTemplateTransformationFramework.Common.Contracts;
 using TextTemplateTransformationFramework.Common.Extensions;

--- a/src/Common.Cmd.Tests/TextTemplateTransformationFramework.Common.Cmd.Tests.csproj
+++ b/src/Common.Cmd.Tests/TextTemplateTransformationFramework.Common.Cmd.Tests.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.55" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/Common.Cmd.Tests/TextTemplateTransformationFramework.Common.Cmd.Tests.csproj
+++ b/src/Common.Cmd.Tests/TextTemplateTransformationFramework.Common.Cmd.Tests.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.55" />
     <PackageReference Include="xunit" Version="2.4.2" />
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Common.Cmd/CommandLineCommands/AddTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/AddTemplateCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
 using TextTemplateTransformationFramework.Common.Cmd.Contracts;
 using TextTemplateTransformationFramework.Common.Contracts;
@@ -27,6 +28,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                 var fileNameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
                 var assemblyNameOption = command.Option<string>("-a|--assembly <ASSEMBLY>", "The template assembly", CommandOptionType.SingleValue);
                 var classNameOption = command.Option<string>("-n|--classname <CLASS>", "The template class name", CommandOptionType.SingleValue);
+                var parametersArgument = command.Argument("Parameters", "Optional parameters to use (name:value)", true);
                 command.HelpOption();
                 command.OnExecute(() =>
                 {
@@ -53,7 +55,9 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                         ? TemplateType.TextTemplate
                         : TemplateType.AssemblyTemplate;
 
-                    _templateInfoRepository.Add(new TemplateInfo(shortName, fileName ?? string.Empty, assemblyName ?? string.Empty, className ?? string.Empty, type));
+                    var parameters = parametersArgument.Values.Where(p => p.Contains(':')).Select(p => new TemplateParameter { Name = p.Split(':')[0], Value = string.Join(":", p.Split(':').Skip(1)) }).ToArray();
+                    
+                    _templateInfoRepository.Add(new TemplateInfo(shortName, fileName ?? string.Empty, assemblyName ?? string.Empty, className ?? string.Empty, type, parameters));
                     app.Out.WriteLine("Template has been added successfully.");
                 });
             });

--- a/src/Common.Cmd/CommandLineCommands/AddTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/AddTemplateCommand.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using McMaster.Extensions.CommandLineUtils;
+using TextTemplateTransformationFramework.Common.Cmd.Contracts;
+using TextTemplateTransformationFramework.Common.Contracts;
+
+namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
+{
+    public class AddTemplateCommand : ICommandLineCommand
+    {
+        private readonly IFileContentsProvider _fileContentsProvider;
+        private readonly ITemplateInfoRepository _templateInfoRepository;
+
+        public AddTemplateCommand(IFileContentsProvider fileContentsProvider, ITemplateInfoRepository templateInfoRepository)
+        {
+            _fileContentsProvider = fileContentsProvider ?? throw new ArgumentNullException(nameof(fileContentsProvider));
+            _templateInfoRepository = templateInfoRepository ?? throw new ArgumentNullException(nameof(templateInfoRepository));
+        }
+
+        public void Initialize(CommandLineApplication app)
+        {
+            if (app == null) throw new ArgumentNullException(nameof(app));
+            app.Command("add-template", command =>
+            {
+                command.Description = "Adds template to the templates list";
+                var debuggerOption = CommandBase.GetDebuggerOption(command);
+                var shortNameOption = command.Option<string>("-s|--shortname <NAME>", "The unique name of the template", CommandOptionType.SingleValue);
+                var fileNameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
+                var assemblyNameOption = command.Option<string>("-a|--assembly <ASSEMBLY>", "The template assembly", CommandOptionType.SingleValue);
+                var classNameOption = command.Option<string>("-n|--classname <CLASS>", "The template class name", CommandOptionType.SingleValue);
+                command.HelpOption();
+                command.OnExecute(() =>
+                {
+                    CommandBase.LaunchDebuggerIfSet(debuggerOption);
+                    var shortName = shortNameOption.Value();
+                    var fileName = fileNameOption.Value();
+                    var assemblyName = assemblyNameOption.Value();
+                    var className = classNameOption.Value();
+
+                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileName, assemblyName, className);
+                    if (!string.IsNullOrEmpty(validationResult))
+                    {
+                        app.Out.WriteLine($"Error: {validationResult}");
+                        return;
+                    }
+
+                    if (string.IsNullOrEmpty(shortName))
+                    {
+                        app.Out.WriteLine("Error: Shortname is required.");
+                        return;
+                    }
+
+                    var type = string.IsNullOrEmpty(assemblyName)
+                        ? TemplateType.TextTemplate
+                        : TemplateType.AssemblyTemplate;
+
+                    _templateInfoRepository.Add(new TemplateInfo(shortName, fileName ?? string.Empty, assemblyName ?? string.Empty, className ?? string.Empty, type));
+                    app.Out.WriteLine("Template has been added successfully.");
+                });
+            });
+        }
+    }
+}

--- a/src/Common.Cmd/CommandLineCommands/AddTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/AddTemplateCommand.cs
@@ -38,25 +38,16 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                     var assemblyName = assemblyNameOption.Value();
                     var className = classNameOption.Value();
 
-                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileName, assemblyName, className);
+                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileName, assemblyName, className, shortName);
                     if (!string.IsNullOrEmpty(validationResult))
                     {
                         app.Out.WriteLine($"Error: {validationResult}");
                         return;
                     }
 
-                    if (string.IsNullOrEmpty(shortName))
-                    {
-                        app.Out.WriteLine("Error: Shortname is required.");
-                        return;
-                    }
-
-                    var type = string.IsNullOrEmpty(assemblyName)
-                        ? TemplateType.TextTemplate
-                        : TemplateType.AssemblyTemplate;
-
+                    var type = CommandBase.GetTemplateType(assemblyName);
                     var parameters = parametersArgument.Values.Where(p => p.Contains(':')).Select(p => new TemplateParameter { Name = p.Split(':')[0], Value = string.Join(":", p.Split(':').Skip(1)) }).ToArray();
-                    
+
                     _templateInfoRepository.Add(new TemplateInfo(shortName, fileName ?? string.Empty, assemblyName ?? string.Empty, className ?? string.Empty, type, parameters));
                     app.Out.WriteLine("Template has been added successfully.");
                 });

--- a/src/Common.Cmd/CommandLineCommands/AddTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/AddTemplateCommand.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
 using TextTemplateTransformationFramework.Common.Cmd.Contracts;
 using TextTemplateTransformationFramework.Common.Contracts;
@@ -18,40 +17,15 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
         }
 
         public void Initialize(CommandLineApplication app)
-        {
-            if (app == null) throw new ArgumentNullException(nameof(app));
-            app.Command("add-template", command =>
-            {
-                command.Description = "Adds template to the templates list";
-                var debuggerOption = CommandBase.GetDebuggerOption(command);
-                var shortNameOption = command.Option<string>("-s|--shortname <NAME>", "The unique name of the template", CommandOptionType.SingleValue);
-                var fileNameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
-                var assemblyNameOption = command.Option<string>("-a|--assembly <ASSEMBLY>", "The template assembly", CommandOptionType.SingleValue);
-                var classNameOption = command.Option<string>("-n|--classname <CLASS>", "The template class name", CommandOptionType.SingleValue);
-                var parametersArgument = command.Argument("Parameters", "Optional parameters to use (name:value)", true);
-                command.HelpOption();
-                command.OnExecute(() =>
-                {
-                    CommandBase.LaunchDebuggerIfSet(debuggerOption);
-                    var shortName = shortNameOption.Value();
-                    var fileName = fileNameOption.Value();
-                    var assemblyName = assemblyNameOption.Value();
-                    var className = classNameOption.Value();
-
-                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileName, assemblyName, className, shortName);
-                    if (!string.IsNullOrEmpty(validationResult))
-                    {
-                        app.Out.WriteLine($"Error: {validationResult}");
-                        return;
-                    }
-
-                    var type = CommandBase.GetTemplateType(assemblyName);
-                    var parameters = parametersArgument.Values.Where(p => p.Contains(':')).Select(p => new TemplateParameter { Name = p.Split(':')[0], Value = string.Join(":", p.Split(':').Skip(1)) }).ToArray();
-
-                    _templateInfoRepository.Add(new TemplateInfo(shortName, fileName ?? string.Empty, assemblyName ?? string.Empty, className ?? string.Empty, type, parameters));
-                    app.Out.WriteLine("Template has been added successfully.");
-                });
-            });
-        }
+            => CommandBase.ModifyGlobalTemplate
+            (
+                app,
+                _fileContentsProvider,
+                _templateInfoRepository.Add,
+                "add-template",
+                "Adds the specified template to the templates list",
+                "Template has been added successfully.",
+                true
+            );
     }
 }

--- a/src/Common.Cmd/CommandLineCommands/CommandBase.cs
+++ b/src/Common.Cmd/CommandLineCommands/CommandBase.cs
@@ -46,14 +46,14 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
             return assemblyLoadContext;
         }
 
-        internal static string GetValidationResult(IFileContentsProvider fileContentsProvider, string filename, string assemblyName, string className)
+        internal static string GetValidationResult(IFileContentsProvider fileContentsProvider, string fileName, string assemblyName, string className)
         {
-            if (string.IsNullOrEmpty(filename) && string.IsNullOrEmpty(assemblyName))
+            if (string.IsNullOrEmpty(fileName) && string.IsNullOrEmpty(assemblyName))
             {
                 return "Either Filename or AssemblyName is required.";
             }
 
-            if (!string.IsNullOrEmpty(filename) && !string.IsNullOrEmpty(assemblyName))
+            if (!string.IsNullOrEmpty(fileName) && !string.IsNullOrEmpty(assemblyName))
             {
                 return "You can either use Filename or AssemblyName, not both.";
             }
@@ -63,9 +63,9 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                 return "When AssemblyName is filled, then ClassName is required.";
             }
 
-            if (!string.IsNullOrEmpty(filename) && !fileContentsProvider.FileExists(filename))
+            if (!string.IsNullOrEmpty(fileName) && !fileContentsProvider.FileExists(fileName))
             {
-                return $"File [{filename}] does not exist.";
+                return $"File [{fileName}] does not exist.";
             }
 
             return null;

--- a/src/Common.Cmd/CommandLineCommands/CommandBase.cs
+++ b/src/Common.Cmd/CommandLineCommands/CommandBase.cs
@@ -46,6 +46,22 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
             return assemblyLoadContext;
         }
 
+        internal static string GetValidationResult(IFileContentsProvider fileContentsProvider, string fileName, string assemblyName, string className, string shortName)
+        {
+            var result = GetValidationResult(fileContentsProvider, fileName, assemblyName, className);
+            if (!string.IsNullOrEmpty(result))
+            {
+                return result;
+            }
+
+            if (string.IsNullOrEmpty(shortName))
+            {
+                return "Shortname is required.";
+            }
+
+            return string.Empty;
+        }
+
         internal static string GetValidationResult(IFileContentsProvider fileContentsProvider, string fileName, string assemblyName, string className)
         {
             if (string.IsNullOrEmpty(fileName) && string.IsNullOrEmpty(assemblyName))
@@ -70,6 +86,11 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
 
             return null;
         }
+
+        internal static TemplateType GetTemplateType(string assemblyName)
+            => string.IsNullOrEmpty(assemblyName)
+                ? TemplateType.TextTemplate
+                : TemplateType.AssemblyTemplate;
 
         [ExcludeFromCodeCoverage]
         internal static void LaunchDebuggerIfSet(CommandOption<string> debuggerOption)

--- a/src/Common.Cmd/CommandLineCommands/ListParametersCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/ListParametersCommand.cs
@@ -12,6 +12,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
     {
         private readonly ITextTemplateProcessor _processor;
         private readonly IFileContentsProvider _fileContentsProvider;
+        private readonly ITemplateInfoRepository _templateInfoRepository;
 #pragma warning disable IDE0079 // Remove unnecessary suppression
 #pragma warning disable S4487 // Unread "private" fields should be removed
 #pragma warning disable IDE0052 // Remove unread private members
@@ -22,10 +23,12 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
 
         public ListParametersCommand(ITextTemplateProcessor processor,
                                      IFileContentsProvider fileContentsProvider,
+                                     ITemplateInfoRepository templateInfoRepository,
                                      IAssemblyService assemblyService)
         {
             _processor = processor ?? throw new ArgumentNullException(nameof(processor));
             _fileContentsProvider = fileContentsProvider ?? throw new ArgumentNullException(nameof(fileContentsProvider));
+            _templateInfoRepository = templateInfoRepository ?? throw new ArgumentNullException(nameof(templateInfoRepository));
             _assemblyService = assemblyService ?? throw new ArgumentNullException(nameof(assemblyService));
         }
 
@@ -36,6 +39,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
             {
                 command.Description = "Lists template parameters";
 
+                var shortNameOption = command.Option<string>("-s|--shortname <NAME>", "The unique name of the template", CommandOptionType.SingleValue);
                 var fileNameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
                 var assemblyNameOption = command.Option<string>("-a|--assembly <ASSEMBLY>", "The template assembly", CommandOptionType.SingleValue);
                 var classNameOption = command.Option<string>("-n|--classname <CLASS>", "The template class name", CommandOptionType.SingleValue);
@@ -45,7 +49,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                 command.OnExecute(() =>
                 {
                     CommandBase.LaunchDebuggerIfSet(debuggerOption);
-                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileNameOption.Value(), assemblyNameOption.Value(), classNameOption.Value());
+                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileNameOption.Value(), assemblyNameOption.Value(), classNameOption.Value(), shortNameOption.Value());
                     if (!string.IsNullOrEmpty(validationResult))
                     {
                         app.Error.WriteLine($"Error: {validationResult}");
@@ -61,7 +65,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                             ? currentDirectoryOption!.Value()
                             : null
                     );
-                    var result = ExtractParameters(fileNameOption.Value(), assemblyNameOption.Value(), classNameOption.Value(), assemblyLoadContext);
+                    var result = ExtractParameters(fileNameOption.Value(), assemblyNameOption.Value(), classNameOption.Value(), shortNameOption.Value(), assemblyLoadContext);
 
                     if (Array.Exists(result.CompilerErrors, e => !e.IsWarning))
                     {
@@ -87,9 +91,31 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
         private ExtractParametersResult ExtractParameters(string fileName,
                                                           string assemblyName,
                                                           string className,
+                                                          string shortName,
                                                           AssemblyLoadContext assemblyLoadContext)
-            => !string.IsNullOrEmpty(fileName)
+        {
+            if (!string.IsNullOrEmpty(shortName))
+            {
+                var info = _templateInfoRepository.FindByShortName(shortName);
+                if (info == null)
+                {
+                    return ExtractParametersResult.Create(Enumerable.Empty<TemplateParameter>(), Array.Empty<CompilerError>(), string.Empty, string.Empty, new InvalidOperationException($"Could not find template with short name {shortName}"));
+                }
+
+                if (info.Type == TemplateType.TextTemplate)
+                {
+                    fileName = info.FileName;
+                }
+                else
+                {
+                    assemblyName = info.AssemblyName;
+                    className = info.ClassName;
+                }
+            }
+
+            return !string.IsNullOrEmpty(fileName)
                 ? _processor.ExtractParameters(new TextTemplate(_fileContentsProvider.GetFileContents(fileName), fileName))
                 : _processor.ExtractParameters(new AssemblyTemplate(assemblyName, className, assemblyLoadContext));
+        }
     }
 }

--- a/src/Common.Cmd/CommandLineCommands/ListParametersCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/ListParametersCommand.cs
@@ -36,7 +36,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
             {
                 command.Description = "Lists template parameters";
 
-                var filenameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
+                var fileNameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
                 var assemblyNameOption = command.Option<string>("-a|--assembly <ASSEMBLY>", "The template assembly", CommandOptionType.SingleValue);
                 var classNameOption = command.Option<string>("-n|--classname <CLASS>", "The template class name", CommandOptionType.SingleValue);
                 var currentDirectoryOption = CommandBase.GetCurrentDirectoryOption(command);
@@ -45,7 +45,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                 command.OnExecute(() =>
                 {
                     CommandBase.LaunchDebuggerIfSet(debuggerOption);
-                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, filenameOption.Value(), assemblyNameOption.Value(), classNameOption.Value());
+                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileNameOption.Value(), assemblyNameOption.Value(), classNameOption.Value());
                     if (!string.IsNullOrEmpty(validationResult))
                     {
                         app.Error.WriteLine($"Error: {validationResult}");
@@ -61,7 +61,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                             ? currentDirectoryOption!.Value()
                             : null
                     );
-                    var result = ExtractParameters(filenameOption.Value(), assemblyNameOption.Value(), classNameOption.Value(), assemblyLoadContext);
+                    var result = ExtractParameters(fileNameOption.Value(), assemblyNameOption.Value(), classNameOption.Value(), assemblyLoadContext);
 
                     if (result.CompilerErrors.Any(e => !e.IsWarning))
                     {
@@ -84,12 +84,12 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
             });
         }
 
-        private ExtractParametersResult ExtractParameters(string filename,
+        private ExtractParametersResult ExtractParameters(string fileName,
                                                           string assemblyName,
                                                           string className,
                                                           AssemblyLoadContext assemblyLoadContext)
-            => !string.IsNullOrEmpty(filename)
-                ? _processor.ExtractParameters(new TextTemplate(_fileContentsProvider.GetFileContents(filename), filename))
+            => !string.IsNullOrEmpty(fileName)
+                ? _processor.ExtractParameters(new TextTemplate(_fileContentsProvider.GetFileContents(fileName), fileName))
                 : _processor.ExtractParameters(new AssemblyTemplate(assemblyName, className, assemblyLoadContext));
     }
 }

--- a/src/Common.Cmd/CommandLineCommands/ListParametersCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/ListParametersCommand.cs
@@ -63,7 +63,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                     );
                     var result = ExtractParameters(fileNameOption.Value(), assemblyNameOption.Value(), classNameOption.Value(), assemblyLoadContext);
 
-                    if (result.CompilerErrors.Any(e => !e.IsWarning))
+                    if (Array.Exists(result.CompilerErrors, e => !e.IsWarning))
                     {
                         app.Error.WriteLine("Compiler errors:");
                         result.CompilerErrors.Select(err => err.ToString()).ForEach(app.Error.WriteLine);

--- a/src/Common.Cmd/CommandLineCommands/ListTemplatesCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/ListTemplatesCommand.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using McMaster.Extensions.CommandLineUtils;
+using TextTemplateTransformationFramework.Common.Cmd.Contracts;
+using TextTemplateTransformationFramework.Common.Contracts;
+using Utilities.Extensions;
+
+namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
+{
+    public class ListTemplatesCommand : ICommandLineCommand
+    {
+        private readonly ITemplateInfoRepository _templateInfoRepository;
+
+        public ListTemplatesCommand(ITemplateInfoRepository templateInfoRepository)
+        {
+            _templateInfoRepository = templateInfoRepository ?? throw new ArgumentNullException(nameof(templateInfoRepository));
+        }
+
+        public void Initialize(CommandLineApplication app)
+        {
+            if (app == null) throw new ArgumentNullException(nameof(app));
+            app.Command("list-templates", command =>
+            {
+                command.Description = "Lists templates";
+                var debuggerOption = CommandBase.GetDebuggerOption(command);
+                command.HelpOption();
+                command.OnExecute(() =>
+                {
+                    CommandBase.LaunchDebuggerIfSet(debuggerOption);
+                    _templateInfoRepository.GetTemplates().ForEach(app.Out.WriteLine);
+                });
+            });
+        }
+    }
+}

--- a/src/Common.Cmd/CommandLineCommands/RemoveTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/RemoveTemplateCommand.cs
@@ -17,38 +17,15 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
         }
 
         public void Initialize(CommandLineApplication app)
-        {
-            if (app == null) throw new ArgumentNullException(nameof(app));
-            app.Command("remove-template", command =>
-            {
-                command.Description = "Removes template from the templates list";
-                var debuggerOption = CommandBase.GetDebuggerOption(command);
-                var shortNameOption = command.Option<string>("-s|--shortname <NAME>", "The unique name of the template", CommandOptionType.SingleValue);
-                var fileNameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
-                var assemblyNameOption = command.Option<string>("-a|--assembly <ASSEMBLY>", "The template assembly", CommandOptionType.SingleValue);
-                var classNameOption = command.Option<string>("-n|--classname <CLASS>", "The template class name", CommandOptionType.SingleValue);
-                command.HelpOption();
-                command.OnExecute(() =>
-                {
-                    CommandBase.LaunchDebuggerIfSet(debuggerOption);
-                    var shortName = shortNameOption.Value();
-                    var fileName = fileNameOption.Value();
-                    var assemblyName = assemblyNameOption.Value();
-                    var className = classNameOption.Value();
-
-                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileName, assemblyName, className, shortName);
-                    if (!string.IsNullOrEmpty(validationResult))
-                    {
-                        app.Out.WriteLine($"Error: {validationResult}");
-                        return;
-                    }
-
-                    var type = CommandBase.GetTemplateType(assemblyName);
-
-                    _templateInfoRepository.Remove(new TemplateInfo(shortName, fileName ?? string.Empty, assemblyName ?? string.Empty, className ?? string.Empty, type, Array.Empty<TemplateParameter>()));
-                    app.Out.WriteLine("Template has been removed successfully.");
-                });
-            });
-        }
+            => CommandBase.ModifyGlobalTemplate
+            (
+                app,
+                _fileContentsProvider,
+                _templateInfoRepository.Remove,
+                "remove-template",
+                "Removes the specified template from the templates list",
+                "Template has been removed successfully.",
+                false
+            );
     }
 }

--- a/src/Common.Cmd/CommandLineCommands/RemoveTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/RemoveTemplateCommand.cs
@@ -53,7 +53,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                         ? TemplateType.TextTemplate
                         : TemplateType.AssemblyTemplate;
 
-                    _templateInfoRepository.Remove(new TemplateInfo(shortName, fileName ?? string.Empty, assemblyName ?? string.Empty, className ?? string.Empty, type));
+                    _templateInfoRepository.Remove(new TemplateInfo(shortName, fileName ?? string.Empty, assemblyName ?? string.Empty, className ?? string.Empty, type, Array.Empty<TemplateParameter>()));
                     app.Out.WriteLine("Template has been removed successfully.");
                 });
             });

--- a/src/Common.Cmd/CommandLineCommands/RemoveTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/RemoveTemplateCommand.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using McMaster.Extensions.CommandLineUtils;
+using TextTemplateTransformationFramework.Common.Cmd.Contracts;
+using TextTemplateTransformationFramework.Common.Contracts;
+
+namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
+{
+    public class RemoveTemplateCommand : ICommandLineCommand
+    {
+        private readonly IFileContentsProvider _fileContentsProvider;
+        private readonly ITemplateInfoRepository _templateInfoRepository;
+
+        public RemoveTemplateCommand(IFileContentsProvider fileContentsProvider, ITemplateInfoRepository templateInfoRepository)
+        {
+            _fileContentsProvider = fileContentsProvider ?? throw new ArgumentNullException(nameof(fileContentsProvider));
+            _templateInfoRepository = templateInfoRepository ?? throw new ArgumentNullException(nameof(templateInfoRepository));
+        }
+
+        public void Initialize(CommandLineApplication app)
+        {
+            if (app == null) throw new ArgumentNullException(nameof(app));
+            app.Command("remove-template", command =>
+            {
+                command.Description = "Removes template from the templates list";
+                var debuggerOption = CommandBase.GetDebuggerOption(command);
+                var shortNameOption = command.Option<string>("-s|--shortname <NAME>", "The unique name of the template", CommandOptionType.SingleValue);
+                var fileNameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
+                var assemblyNameOption = command.Option<string>("-a|--assembly <ASSEMBLY>", "The template assembly", CommandOptionType.SingleValue);
+                var classNameOption = command.Option<string>("-n|--classname <CLASS>", "The template class name", CommandOptionType.SingleValue);
+                command.HelpOption();
+                command.OnExecute(() =>
+                {
+                    CommandBase.LaunchDebuggerIfSet(debuggerOption);
+                    var shortName = shortNameOption.Value();
+                    var fileName = fileNameOption.Value();
+                    var assemblyName = assemblyNameOption.Value();
+                    var className = classNameOption.Value();
+
+                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileName, assemblyName, className);
+                    if (!string.IsNullOrEmpty(validationResult))
+                    {
+                        app.Out.WriteLine($"Error: {validationResult}");
+                        return;
+                    }
+
+                    if (string.IsNullOrEmpty(shortName))
+                    {
+                        app.Out.WriteLine("Error: Shortname is required.");
+                        return;
+                    }
+
+                    var type = string.IsNullOrEmpty(assemblyName)
+                        ? TemplateType.TextTemplate
+                        : TemplateType.AssemblyTemplate;
+
+                    _templateInfoRepository.Remove(new TemplateInfo(shortName, fileName ?? string.Empty, assemblyName ?? string.Empty, className ?? string.Empty, type));
+                    app.Out.WriteLine("Template has been removed successfully.");
+                });
+            });
+        }
+    }
+}

--- a/src/Common.Cmd/CommandLineCommands/RemoveTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/RemoveTemplateCommand.cs
@@ -36,22 +36,14 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                     var assemblyName = assemblyNameOption.Value();
                     var className = classNameOption.Value();
 
-                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileName, assemblyName, className);
+                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileName, assemblyName, className, shortName);
                     if (!string.IsNullOrEmpty(validationResult))
                     {
                         app.Out.WriteLine($"Error: {validationResult}");
                         return;
                     }
 
-                    if (string.IsNullOrEmpty(shortName))
-                    {
-                        app.Out.WriteLine("Error: Shortname is required.");
-                        return;
-                    }
-
-                    var type = string.IsNullOrEmpty(assemblyName)
-                        ? TemplateType.TextTemplate
-                        : TemplateType.AssemblyTemplate;
+                    var type = CommandBase.GetTemplateType(assemblyName);
 
                     _templateInfoRepository.Remove(new TemplateInfo(shortName, fileName ?? string.Empty, assemblyName ?? string.Empty, className ?? string.Empty, type, Array.Empty<TemplateParameter>()));
                     app.Out.WriteLine("Template has been removed successfully.");

--- a/src/Common.Cmd/CommandLineCommands/RunTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/RunTemplateCommand.cs
@@ -136,7 +136,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
             }
             var result = _processor.Process(template, parameters);
 
-            if (result.CompilerErrors.Any(e => !e.IsWarning))
+            if (Array.Exists(result.CompilerErrors, e => !e.IsWarning))
             {
                 app.Error.WriteLine("Compiler errors:");
                 result.CompilerErrors.Select(err => err.ToString()).ForEach(app.Error.WriteLine);

--- a/src/Common.Cmd/CommandLineCommands/RunTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/RunTemplateCommand.cs
@@ -44,7 +44,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
             {
                 command.Description = "Runs the template, and shows the template output";
 
-                var filenameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
+                var fileNameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
                 var outputOption = command.Option<string>("-o|--output <PATH>", "The output filename", CommandOptionType.SingleValue);
                 var diagnosticDumpOutputOption = command.Option<string>("-diag|--diagnosticoutput <PATH>", "The diagnostic output filename", CommandOptionType.SingleValue);
                 var parametersArgument = command.Argument("Parameters", "Optional parameters to use (name:value)", true);
@@ -60,20 +60,20 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                 command.OnExecute(() =>
                 {
                     CommandBase.LaunchDebuggerIfSet(debuggerOption);
-                    var filename = filenameOption.Value();
+                    var fileName = fileNameOption.Value();
                     var assemblyName = assemblyNameOption.Value();
                     var className = classNameOption.Value();
 
-                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, filename, assemblyName, className);
+                    var validationResult = CommandBase.GetValidationResult(_fileContentsProvider, fileName, assemblyName, className);
                     if (!string.IsNullOrEmpty(validationResult))
                     {
                         app.Out.WriteLine($"Error: {validationResult}");
                         return;
                     }
 
-                    CommandBase.Watch(app, watchOption, !string.IsNullOrEmpty(filename) ? filename : assemblyName, () =>
+                    CommandBase.Watch(app, watchOption, !string.IsNullOrEmpty(fileName) ? fileName : assemblyName, () =>
                     {
-                        var result = ProcessTemplate(app, parametersArgument, interactiveOption, currentDirectoryOption, filename, assemblyName, className);
+                        var result = ProcessTemplate(app, parametersArgument, interactiveOption, currentDirectoryOption, fileName, assemblyName, className);
                         if (!result.Success)
                         {
                             return;

--- a/src/Common.Cmd/CommandLineCommands/RunTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/RunTemplateCommand.cs
@@ -78,7 +78,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
 
                     CommandBase.Watch(app, watchOption, !string.IsNullOrEmpty(fileName) ? fileName : assemblyName, () =>
                     {
-                        var result = ProcessTemplate(app, parametersArgument, interactiveOption, currentDirectoryOption, fileName, assemblyName, className, shortName);
+                        var result = ProcessTemplate(app, parametersArgument, interactiveOption, currentDirectoryOption, (fileName, assemblyName, className, shortName));
                         if (!result.Success)
                         {
                             app.Error.WriteLine("Exception occured while processing the template:");
@@ -112,43 +112,43 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                                                                                                                      CommandArgument parametersArgument,
                                                                                                                      CommandOption<string> interactiveOption,
                                                                                                                      CommandOption<string> currentDirectoryOption,
-                                                                                                                     string filename,
+                                                                                                                     (string filename,
                                                                                                                      string assemblyName,
                                                                                                                      string className,
-                                                                                                                     string shortName)
+                                                                                                                     string shortName) names)
 #pragma warning restore S1172 // Unused method parameters should be removed
 #pragma warning restore IDE0079 // Remove unnecessary suppression
         {
-            if (!string.IsNullOrEmpty(shortName))
+            if (!string.IsNullOrEmpty(names.shortName))
             {
-                var info = _templateInfoRepository.FindByShortName(shortName);
+                var info = _templateInfoRepository.FindByShortName(names.shortName);
                 if (info == null)
                 {
-                    return (false, ProcessResult.Create(Array.Empty<CompilerError>(), string.Empty, string.Empty, string.Empty, string.Empty, new InvalidOperationException($"Could not find template with short name {shortName}")), null);
+                    return (false, ProcessResult.Create(Array.Empty<CompilerError>(), string.Empty, string.Empty, string.Empty, string.Empty, new InvalidOperationException($"Could not find template with short name {names.shortName}")), null);
                 }
 
                 if (info.Type == TemplateType.TextTemplate)
                 {
-                    filename = info.FileName;
+                    names.filename = info.FileName;
                 }
                 else
                 {
-                    assemblyName = info.AssemblyName;
-                    className = info.ClassName;
+                    names.assemblyName = info.AssemblyName;
+                    names.className = info.ClassName;
                 }
             }
 
-            if (!string.IsNullOrEmpty(filename))
+            if (!string.IsNullOrEmpty(names.filename))
             {
-                var x = ProcessTextTemplate(filename, app, interactiveOption.HasValue(), parametersArgument.Values);
+                var x = ProcessTextTemplate(names.filename, app, interactiveOption.HasValue(), parametersArgument.Values);
                 return (x.Success, x.Result, null);
             }
             else
             {
 #if !NETFRAMEWORK
-                var x = ProcessAssemblyTemplate(assemblyName, className, app, interactiveOption.HasValue(), parametersArgument.Values, currentDirectoryOption?.HasValue() == true, currentDirectoryOption?.HasValue() == true ? currentDirectoryOption!.Value() : null);
+                var x = ProcessAssemblyTemplate(names.assemblyName, names.className, app, interactiveOption.HasValue(), parametersArgument.Values, currentDirectoryOption?.HasValue() == true, currentDirectoryOption?.HasValue() == true ? currentDirectoryOption!.Value() : null);
 #else
-                var x = ProcessAssemblyTemplate(assemblyName, className, app, interactiveOption.HasValue(), parametersArgument.Values, false, null);
+                var x = ProcessAssemblyTemplate(names.assemblyName, names.className, app, interactiveOption.HasValue(), parametersArgument.Values, false, null);
 #endif
 #if !NETFRAMEWORK
                 return (x.Success, x.Result, x.AssemblyLoadContext);

--- a/src/Common.Cmd/CommandLineCommands/RunTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/RunTemplateCommand.cs
@@ -81,8 +81,6 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                         var result = ProcessTemplate(app, parametersArgument, interactiveOption, currentDirectoryOption, (fileName, assemblyName, className, shortName));
                         if (!result.Success)
                         {
-                            app.Error.WriteLine("Exception occured while processing the template:");
-                            app.Error.WriteLine(result.ProcessResult.Exception);
                             return;
                         }
 
@@ -124,7 +122,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                 var info = _templateInfoRepository.FindByShortName(names.shortName);
                 if (info == null)
                 {
-                    return (false, ProcessResult.Create(Array.Empty<CompilerError>(), string.Empty, string.Empty, string.Empty, string.Empty, new InvalidOperationException($"Could not find template with short name {names.shortName}")), null);
+                    return (true, ProcessResult.Create(Array.Empty<CompilerError>(), string.Empty, string.Empty, string.Empty, string.Empty, new InvalidOperationException($"Could not find template with short name {names.shortName}")), null);
                 }
 
                 if (info.Type == TemplateType.TextTemplate)

--- a/src/Common.Cmd/CommandLineCommands/RunTemplateCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/RunTemplateCommand.cs
@@ -81,6 +81,8 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                         var result = ProcessTemplate(app, parametersArgument, interactiveOption, currentDirectoryOption, fileName, assemblyName, className, shortName);
                         if (!result.Success)
                         {
+                            app.Error.WriteLine("Exception occured while processing the template:");
+                            app.Error.WriteLine(result.ProcessResult.Exception);
                             return;
                         }
 

--- a/src/Common.Cmd/CommandLineCommands/SourceCodeCommand.cs
+++ b/src/Common.Cmd/CommandLineCommands/SourceCodeCommand.cs
@@ -29,7 +29,7 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
             {
                 command.Description = "Generates the template, and shows the template source code";
 
-                var filenameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
+                var fileNameOption = command.Option<string>("-f|--filename <PATH>", "The template filename", CommandOptionType.SingleValue);
                 var outputOption = command.Option<string>("-o|--output <PATH>", "The output filename", CommandOptionType.SingleValue);
                 var diagnosticDumpOutputOption = command.Option<string>("-diag|--diagnosticoutput <PATH>", "The diagnostic output filename", CommandOptionType.SingleValue);
                 var parametersArgument = command.Argument("Parameters", "Optional parameters to use (name:value)", true);
@@ -40,22 +40,22 @@ namespace TextTemplateTransformationFramework.Common.Cmd.CommandLineCommands
                 command.OnExecute(() =>
                 {
                     CommandBase.LaunchDebuggerIfSet(debuggerOption);
-                    var filename = filenameOption.Value();
+                    var fileName = fileNameOption.Value();
                     var parameters = parametersArgument.Values.Where(p => p.Contains(':')).Select(p => new TemplateParameter { Name = p.Split(':')[0], Value = string.Join(":", p.Split(':').Skip(1)) }).ToArray();
 
-                    if (string.IsNullOrEmpty(filename))
+                    if (string.IsNullOrEmpty(fileName))
                     {
                         app.Error.WriteLine("Error: Filename is required.");
                         return;
                     }
 
-                    if (!_fileContentsProvider.FileExists(filename))
+                    if (!_fileContentsProvider.FileExists(fileName))
                     {
-                        app.Error.WriteLine($"Error: File [{filename}] does not exist.");
+                        app.Error.WriteLine($"Error: File [{fileName}] does not exist.");
                         return;
                     }
 
-                    var result = _processor.PreProcess(new TextTemplate(_fileContentsProvider.GetFileContents(filename), filename), parameters);
+                    var result = _processor.PreProcess(new TextTemplate(_fileContentsProvider.GetFileContents(fileName), fileName), parameters);
 
                     if (!string.IsNullOrEmpty(result.Exception))
                     {

--- a/src/Common.Cmd/Default/UserInput.cs
+++ b/src/Common.Cmd/Default/UserInput.cs
@@ -1,4 +1,5 @@
-﻿using TextTemplateTransformationFramework.Common.Cmd.Contracts;
+﻿using System;
+using TextTemplateTransformationFramework.Common.Cmd.Contracts;
 using Utilities.Extensions;
 
 namespace TextTemplateTransformationFramework.Common.Cmd.Default
@@ -6,8 +7,15 @@ namespace TextTemplateTransformationFramework.Common.Cmd.Default
     public class UserInput : IUserInput
     {
         public string GetValue(TemplateParameter parameter)
-            => parameter.Type.IsEnum
+        {
+            if (parameter == null)
+            {
+                throw new ArgumentNullException(nameof(parameter));
+            }
+
+            return parameter.Type.IsEnum
                 ? Sharprompt.Prompt.Select(parameter.DisplayName.WhenNullOrEmpty(parameter.Name), parameter.PossibleValues)
                 : Sharprompt.Prompt.Input<string>(parameter.DisplayName.WhenNullOrEmpty(parameter.Name));
+        }
     }
 }

--- a/src/Common.Cmd/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Common.Cmd/Extensions/ServiceCollectionExtensions.cs
@@ -22,6 +22,9 @@ namespace TextTemplateTransformationFramework.Common.Cmd.Extensions
                 .AddSingleton<ICommandLineCommand, RunTemplateCommand>()
                 .AddSingleton<ICommandLineCommand, SourceCodeCommand>()
                 .AddSingleton<ICommandLineCommand, RunCodeGenerationProviderAssemblyCommand>()
+                .AddSingleton<ICommandLineCommand, ListTemplatesCommand>()
+                .AddSingleton<ICommandLineCommand, AddTemplateCommand>()
+                .AddSingleton<ICommandLineCommand, RemoveTemplateCommand>()
                 .AddSingleton<IUserInput, UserInput>();
         }
     }

--- a/src/Common.Tests/Default/TemplateCodeOutputTests.cs
+++ b/src/Common.Tests/Default/TemplateCodeOutputTests.cs
@@ -20,5 +20,15 @@ namespace TextTemplateTransformationFramework.Common.Tests.Default
             // Act
             action.Should().Throw<ArgumentNullException>().WithParameterName("codeGeneratorResult");
         }
+
+        [Fact]
+        public void Ctor_Throws_On_Null_PreviousResult()
+        {
+            // Arrange
+            var action = new Action(() => _ = new TemplateCodeOutput<TemplateCodeOutputTests>(Enumerable.Empty<ITemplateToken<TemplateCodeOutputTests>>(), string.Empty, null));
+
+            // Act
+            action.Should().Throw<ArgumentNullException>().WithParameterName("previousResult");
+        }
     }
 }

--- a/src/Common.Tests/Default/TemplateInfoRepositoryTests.cs
+++ b/src/Common.Tests/Default/TemplateInfoRepositoryTests.cs
@@ -107,6 +107,21 @@ namespace TextTemplateTransformationFramework.Common.Tests.Default
         }
 
         [Fact]
+        public void Add_Creates_Directory_When_It_Does_Not_Exist_Yet()
+        {
+            // Arrange
+            _fileContentsProviderMock.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(false);
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+            var templateInfo = new TemplateInfo("MyTemplate", "my.template", "", "", TemplateType.TextTemplate, new[] { new TemplateParameter { Name = "MyParameter", Value = "123" } });
+
+            // Act
+            sut.Add(templateInfo);
+
+            // Assert
+            _fileContentsProviderMock.Verify(x => x.CreateDirectory(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
         public void Update_Updates_The_Specified_Template_Correctly()
         {
             // Arrange

--- a/src/Common.Tests/Default/TemplateInfoRepositoryTests.cs
+++ b/src/Common.Tests/Default/TemplateInfoRepositoryTests.cs
@@ -39,6 +39,16 @@ namespace TextTemplateTransformationFramework.Common.Tests.Default
         }
 
         [Fact]
+        public void Update_Throws_On_Null_Template()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+
+            // Act
+            sut.Invoking(x => x.Update(null)).Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
         public void Remove_Throws_On_Null_Template()
         {
             // Arrange
@@ -47,7 +57,6 @@ namespace TextTemplateTransformationFramework.Common.Tests.Default
             // Act
             sut.Invoking(x => x.Remove(null)).Should().Throw<ArgumentNullException>();
         }
-
         [Fact]
         public void Add_Throws_On_Duplicate_Template()
         {
@@ -58,6 +67,17 @@ namespace TextTemplateTransformationFramework.Common.Tests.Default
 
             // Act & Assert
             sut.Invoking(x => x.Add(templateInfo)).Should().Throw<ArgumentOutOfRangeException>().WithMessage("Template already exists (Parameter 'templateInfo')");
+        }
+
+        [Fact]
+        public void Update_Throws_On_Non_Existing_Template()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+
+            // Act
+            sut.Invoking(x => x.Update(new TemplateInfo("", "", "", "", TemplateType.TextTemplate, Array.Empty<TemplateParameter>())))
+               .Should().Throw<ArgumentOutOfRangeException>().WithMessage("Template was not found (Parameter 'templateInfo')");
         }
 
         [Fact]
@@ -85,6 +105,20 @@ namespace TextTemplateTransformationFramework.Common.Tests.Default
             _contents.Should().StartWith(@"{""Templates"":[{""ShortName"":""MyTemplate"",""FileName"":""my.template"",""AssemblyName"":"""",""ClassName"":"""",""Type"":""TextTemplate"",""Parameters"":[{""Name"":""MyParameter"",""Type"":null,""EditorAttributeEditorTypeName"":null,""EditorAttributeEditorBaseTypeName"":null,""TypeConverterTypeName"":null,""Value"":""123"",""OmitValueAssignment"":false,""Description"":null,""DisplayName"":null,""Browsable"":false,""ReadOnly"":false,""PossibleValues"":null}]}]}");
         }
 
+        [Fact]
+        public void Update_Updates_The_Specified_Template_Correctly()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+            var templateInfo = new TemplateInfo("MyTemplate", "my.template", "", "", TemplateType.TextTemplate, new[] { new TemplateParameter { Name = "MyParameter", Value = "123" } });
+            sut.Add(templateInfo);
+
+            // Act
+            sut.Update(templateInfo.Update("updated", Array.Empty<TemplateParameter>()));
+
+            // Assert
+            _contents.Should().StartWith(@"{""Templates"":[{""ShortName"":""updated"",""FileName"":""my.template"",""AssemblyName"":"""",""ClassName"":"""",""Type"":""TextTemplate"",""Parameters"":[]}]}");
+        }
         [Fact]
         public void Remove_Removes_The_Specified_Template_Correctly()
         {

--- a/src/Common.Tests/Default/TemplateInfoRepositoryTests.cs
+++ b/src/Common.Tests/Default/TemplateInfoRepositoryTests.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Linq;
+using CrossCutting.Common.Testing;
+using FluentAssertions;
+using Moq;
+using TextTemplateTransformationFramework.Common.Contracts;
+using TextTemplateTransformationFramework.Common.Default;
+using Xunit;
+
+namespace TextTemplateTransformationFramework.Common.Tests.Default
+{
+    public class TemplateInfoRepositoryTests
+    {
+        private readonly Mock<IFileContentsProvider> _fileContentsProviderMock = new();
+        private string _contents = "";
+
+        public TemplateInfoRepositoryTests()
+        {
+            _fileContentsProviderMock.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
+            _fileContentsProviderMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns(() => !string.IsNullOrEmpty(_contents));
+            _fileContentsProviderMock.Setup(x => x.GetFileContents(It.IsAny<string>())).Returns(() => _contents);
+            _fileContentsProviderMock.Setup(x => x.WriteFileContents(It.IsAny<string>(), It.IsAny<string>())).Callback<string, string>((path, contents) => _contents = contents);
+        }
+
+        [Fact]
+        public void Ctor_Throws_On_Null_Arguments()
+        {
+            TestHelpers.ConstructorMustThrowArgumentNullException(typeof(TemplateInfoRepository));
+        }
+
+        [Fact]
+        public void Add_Throws_On_Null_Template()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+
+            // Act
+            sut.Invoking(x => x.Add(null)).Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Remove_Throws_On_Null_Template()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+
+            // Act
+            sut.Invoking(x => x.Remove(null)).Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Add_Throws_On_Duplicate_Template()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+            var templateInfo = new TemplateInfo("MyTemplate", "my.template", "", "", TemplateType.TextTemplate, new[] { new TemplateParameter { Name = "MyParameter", Value = "123" } });
+            sut.Add(templateInfo);
+
+            // Act & Assert
+            sut.Invoking(x => x.Add(templateInfo)).Should().Throw<ArgumentOutOfRangeException>().WithMessage("Template already exists (Parameter 'templateInfo')");
+        }
+
+        [Fact]
+        public void Remove_Throws_On_Non_Existing_Template()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+
+            // Act
+            sut.Invoking(x => x.Remove(new TemplateInfo("", "", "", "", TemplateType.TextTemplate, Array.Empty<TemplateParameter>())))
+               .Should().Throw<ArgumentOutOfRangeException>().WithMessage("Template was not found (Parameter 'templateInfo')");
+        }
+
+        [Fact]
+        public void Add_Adds_The_Specified_Template_Corectly()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+            var templateInfo = new TemplateInfo("MyTemplate", "my.template", "", "", TemplateType.TextTemplate, new[] { new TemplateParameter { Name = "MyParameter", Value = "123" } });
+
+            // Act
+            sut.Add(templateInfo);
+
+            // Assert
+            _contents.Should().StartWith(@"{""Templates"":[{""ShortName"":""MyTemplate"",""FileName"":""my.template"",""AssemblyName"":"""",""ClassName"":"""",""Type"":""TextTemplate"",""Parameters"":[{""Name"":""MyParameter"",""Type"":null,""EditorAttributeEditorTypeName"":null,""EditorAttributeEditorBaseTypeName"":null,""TypeConverterTypeName"":null,""Value"":""123"",""OmitValueAssignment"":false,""Description"":null,""DisplayName"":null,""Browsable"":false,""ReadOnly"":false,""PossibleValues"":null}]}]}");
+        }
+
+        [Fact]
+        public void Remove_Removes_The_Specified_Template_Correctly()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+            var templateInfo = new TemplateInfo("MyTemplate", "my.template", "", "", TemplateType.TextTemplate, new[] { new TemplateParameter { Name = "MyParameter", Value = "123" } });
+            sut.Add(templateInfo);
+
+            // Act
+            sut.Remove(templateInfo);
+
+            // Assert
+            _contents.Should().StartWith(@"{""Templates"":[]}");
+        }
+
+        [Fact]
+        public void GetTemplates_Returns_Empty_Result_When_Contents_Is_Empty()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+
+            // Act
+            var actual = sut.GetTemplates().ToArray();
+
+            // Assert
+            actual.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GetTemplates_Returns_Correct_Result_When_Contents_Is_Not_Empty()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+            var templateInfo = new TemplateInfo("MyTemplate", "my.template", "", "", TemplateType.TextTemplate, new[] { new TemplateParameter { Name = "MyParameter", Value = "123" } });
+            sut.Add(templateInfo);
+
+            // Act
+            var actual = sut.GetTemplates().ToArray();
+
+            // Assert
+            actual.Should().BeEquivalentTo(new[] { templateInfo });
+        }
+    }
+}

--- a/src/Common.Tests/Default/TemplateInfoRepositoryTests.cs
+++ b/src/Common.Tests/Default/TemplateInfoRepositoryTests.cs
@@ -57,6 +57,7 @@ namespace TextTemplateTransformationFramework.Common.Tests.Default
             // Act
             sut.Invoking(x => x.Remove(null)).Should().Throw<ArgumentNullException>();
         }
+
         [Fact]
         public void Add_Throws_On_Duplicate_Template()
         {
@@ -119,6 +120,7 @@ namespace TextTemplateTransformationFramework.Common.Tests.Default
             // Assert
             _contents.Should().StartWith(@"{""Templates"":[{""ShortName"":""updated"",""FileName"":""my.template"",""AssemblyName"":"""",""ClassName"":"""",""Type"":""TextTemplate"",""Parameters"":[]}]}");
         }
+
         [Fact]
         public void Remove_Removes_The_Specified_Template_Correctly()
         {
@@ -160,6 +162,46 @@ namespace TextTemplateTransformationFramework.Common.Tests.Default
 
             // Assert
             actual.Should().BeEquivalentTo(new[] { templateInfo });
+        }
+
+        [Fact]
+        public void FindByShortName_Throws_On_Empty_ShortName()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+
+            // Act & Assert
+            sut.Invoking(x => x.FindByShortName(null)).Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void FindByShortName_Returns_Null_When_Not_Found()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+            var templateInfo = new TemplateInfo("MyTemplate", "my.template", "", "", TemplateType.TextTemplate, new[] { new TemplateParameter { Name = "MyParameter", Value = "123" } });
+            sut.Add(templateInfo);
+
+            // Act
+            var actual = sut.FindByShortName("nonexisting");
+
+            // Assert
+            actual.Should().BeNull();
+        }
+
+        [Fact]
+        public void FindByShortName_Returns_TemplateInfo_When_Found()
+        {
+            // Arrange
+            var sut = new TemplateInfoRepository(_fileContentsProviderMock.Object);
+            var templateInfo = new TemplateInfo("MyTemplate", "my.template", "", "", TemplateType.TextTemplate, new[] { new TemplateParameter { Name = "MyParameter", Value = "123" } });
+            sut.Add(templateInfo);
+
+            // Act
+            var actual = sut.FindByShortName("MyTemplate");
+
+            // Assert
+            actual.Should().NotBeNull();
         }
     }
 }

--- a/src/Common.Tests/Default/TemplateInitializeParameterSetterTests.cs
+++ b/src/Common.Tests/Default/TemplateInitializeParameterSetterTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using TextTemplateTransformationFramework.Common.Default;
+using Xunit;
+
+namespace TextTemplateTransformationFramework.Common.Tests.Default
+{
+    [ExcludeFromCodeCoverage]
+    public class TemplateInitializeParameterSetterTests
+    {
+        [Fact]
+        public void Set_Throws_On_Null_Context()
+        {
+            // Arrange
+            var sut = new TemplateInitializeParameterSetter<TemplateInitializeParameterSetterTests>();
+            var action = new Action(() => sut.Set(null));
+
+            // Act & Assert
+            action.Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/src/Common.Tests/Extensions/ObjectExtensionsTests.cs
+++ b/src/Common.Tests/Extensions/ObjectExtensionsTests.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using TextTemplateTransformationFramework.Common.Extensions;
+using Xunit;
+
+namespace TextTemplateTransformationFramework.Common.Tests.Extensions
+{
+    [ExcludeFromCodeCoverage]
+    public class ObjectExtensionsTests
+    {
+        [Fact]
+        public void ConvertValue_Throws_On_Null_Type()
+        {
+            this.Invoking(x => x.ConvertValue(null)).Should().Throw<ArgumentNullException>().WithParameterName("type");
+        }
+    }
+}

--- a/src/Common.Tests/SectionProcessResultTests.cs
+++ b/src/Common.Tests/SectionProcessResultTests.cs
@@ -103,5 +103,13 @@ namespace TextTemplateTransformationFramework.Common.Tests
             // Assert
             actual.PassThrough.Should().BeFalse();
         }
+
+        [Fact]
+        public void Create_Throws_On_Null_Data_Argument()
+        {
+            // Act & Assert
+            this.Invoking(_ => SectionProcessResult.Create<SectionProcessResultTests>(null))
+                .Should().Throw<ArgumentNullException>().WithParameterName("data");
+        }
     }
 }

--- a/src/Common.Tests/TemplateInfoTests.cs
+++ b/src/Common.Tests/TemplateInfoTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using FluentAssertions;
+using Xunit;
+
+namespace TextTemplateTransformationFramework.Common.Tests
+{
+    public class TemplateInfoTests
+    {
+        [Fact]
+        public void Ctor_Throws_On_Null_ShortName()
+        {
+            this.Invoking(_ => new TemplateInfo(null, "", "", "", default, Array.Empty<TemplateParameter>()))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Ctor_Throws_On_Null_FileName()
+        {
+            this.Invoking(_ => new TemplateInfo("", null, "", "", default, Array.Empty<TemplateParameter>()))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Ctor_Throws_On_Null_AssemblyName()
+        {
+            this.Invoking(_ => new TemplateInfo("", "", null, "", default, Array.Empty<TemplateParameter>()))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Ctor_Throws_On_Null_ClassName()
+        {
+            this.Invoking(_ => new TemplateInfo("", "", "", null, default, Array.Empty<TemplateParameter>()))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Ctor_Throws_On_Null_Parameters()
+        {
+            this.Invoking(_ => new TemplateInfo("", "", "", "", default, null))
+                .Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/src/Common.Tests/TextTemplateTransformationFramework.Common.Tests.csproj
+++ b/src/Common.Tests/TextTemplateTransformationFramework.Common.Tests.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.55" />
     <PackageReference Include="xunit" Version="2.4.2" />
@@ -35,7 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Common.Tests/TextTemplateTransformationFramework.Common.Tests.csproj
+++ b/src/Common.Tests/TextTemplateTransformationFramework.Common.Tests.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.55" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/Common/Contracts/IFileContentsProvider.cs
+++ b/src/Common/Contracts/IFileContentsProvider.cs
@@ -2,8 +2,10 @@
 {
     public interface IFileContentsProvider
     {
+        bool DirectoryExists(string directory);
         bool FileExists(string fileName);
         string GetFileContents(string fileName);
         void WriteFileContents(string path, string contents);
+        void CreateDirectory(string directory);
     }
 }

--- a/src/Common/Contracts/ITemplateInfoRepository.cs
+++ b/src/Common/Contracts/ITemplateInfoRepository.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace TextTemplateTransformationFramework.Common.Contracts
+{
+    public interface ITemplateInfoRepository
+    {
+        IEnumerable<TemplateInfo> GetTemplates();
+        void Add(TemplateInfo templateInfo);
+        void Remove(TemplateInfo templateInfo);
+    }
+}

--- a/src/Common/Contracts/ITemplateInfoRepository.cs
+++ b/src/Common/Contracts/ITemplateInfoRepository.cs
@@ -6,6 +6,7 @@ namespace TextTemplateTransformationFramework.Common.Contracts
     {
         IEnumerable<TemplateInfo> GetTemplates();
         void Add(TemplateInfo templateInfo);
+        void Update(TemplateInfo templateInfo);
         void Remove(TemplateInfo templateInfo);
     }
 }

--- a/src/Common/Contracts/ITemplateInfoRepository.cs
+++ b/src/Common/Contracts/ITemplateInfoRepository.cs
@@ -8,5 +8,6 @@ namespace TextTemplateTransformationFramework.Common.Contracts
         void Add(TemplateInfo templateInfo);
         void Update(TemplateInfo templateInfo);
         void Remove(TemplateInfo templateInfo);
+        TemplateInfo FindByShortName(string shortName);
     }
 }

--- a/src/Common/Default/TemplateCodeOutput.cs
+++ b/src/Common/Default/TemplateCodeOutput.cs
@@ -35,13 +35,17 @@ namespace TextTemplateTransformationFramework.Common.Default
                                   string sourceCode,
                                   TemplateCodeOutput<TState> previousResult)
             : this(sourceTokens,
-                   new CodeGeneratorResult(sourceCode, previousResult.Language, previousResult.Errors ?? Enumerable.Empty<CompilerError>()),
-                   previousResult.OutputExtension,
-                   previousResult.ReferencedAssemblies,
-                   previousResult.PackageReferences,
-                   previousResult.ClassName,
-                   previousResult.TempPath)
+                   new CodeGeneratorResult(sourceCode, previousResult?.Language ?? "C#", previousResult?.Errors ?? Enumerable.Empty<CompilerError>()),
+                   previousResult?.OutputExtension,
+                   previousResult?.ReferencedAssemblies,
+                   previousResult?.PackageReferences,
+                   previousResult?.ClassName,
+                   previousResult?.TempPath)
         {
+            if (previousResult == null)
+            {
+                throw new ArgumentNullException(nameof(previousResult));
+            }
         }
 
         public string Language { get; }

--- a/src/Common/Default/TemplateInfoRepository.cs
+++ b/src/Common/Default/TemplateInfoRepository.cs
@@ -96,7 +96,14 @@ namespace TextTemplateTransformationFramework.Common.Default
         }
 
         public TemplateInfo FindByShortName(string shortName)
-            => GetTemplates().FirstOrDefault(x => x.ShortName.Equals(shortName, StringComparison.InvariantCultureIgnoreCase));
+        {
+            if (string.IsNullOrEmpty(shortName))
+            {
+                throw new ArgumentOutOfRangeException(nameof(shortName), "Short name is required");
+            }
+
+            return GetTemplates().FirstOrDefault(x => x.ShortName.Equals(shortName, StringComparison.InvariantCultureIgnoreCase));
+        }
 
         private static string GetFileName() => Path.Combine(GetDirectory(), "templates.config");
 

--- a/src/Common/Default/TemplateInfoRepository.cs
+++ b/src/Common/Default/TemplateInfoRepository.cs
@@ -95,6 +95,9 @@ namespace TextTemplateTransformationFramework.Common.Default
             Save(templates);
         }
 
+        public TemplateInfo FindByShortName(string shortName)
+            => GetTemplates().FirstOrDefault(x => x.ShortName.Equals(shortName, StringComparison.InvariantCultureIgnoreCase));
+
         private static string GetFileName() => Path.Combine(GetDirectory(), "templates.config");
 
         private static string GetDirectory() => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "T4Plus");

--- a/src/Common/Default/TemplateInfoRepository.cs
+++ b/src/Common/Default/TemplateInfoRepository.cs
@@ -85,12 +85,7 @@ namespace TextTemplateTransformationFramework.Common.Default
             }
 
             var templates = GetTemplates().ToList();
-            var templateToRemove = FindTemplate(templateInfo, templates);
-            if (templateToRemove == null)
-            {
-                throw new ArgumentOutOfRangeException(nameof(templateInfo), "Template was not found");
-            }
-
+            var templateToRemove = FindTemplate(templateInfo, templates) ?? throw new ArgumentOutOfRangeException(nameof(templateInfo), "Template was not found");
             templates.Remove(templateToRemove);
             Save(templates);
         }

--- a/src/Common/Default/TemplateInfoRepository.cs
+++ b/src/Common/Default/TemplateInfoRepository.cs
@@ -102,7 +102,7 @@ namespace TextTemplateTransformationFramework.Common.Default
                 throw new ArgumentOutOfRangeException(nameof(shortName), "Short name is required");
             }
 
-            return GetTemplates().FirstOrDefault(x => x.ShortName.Equals(shortName, StringComparison.InvariantCultureIgnoreCase));
+            return GetTemplates().FirstOrDefault(x => x.ShortName.Equals(shortName, StringComparison.OrdinalIgnoreCase));
         }
 
         private static string GetFileName() => Path.Combine(GetDirectory(), "templates.config");

--- a/src/Common/Default/TemplateInfoRepository.cs
+++ b/src/Common/Default/TemplateInfoRepository.cs
@@ -10,7 +10,11 @@ namespace TextTemplateTransformationFramework.Common.Default
 {
     public class TemplateInfoRepository : ITemplateInfoRepository
     {
-        private static readonly JsonSerializerSettings _settings = new() { Converters = new[] { new StringEnumConverter() } };
+        private static readonly JsonSerializerSettings _settings = new()
+        {
+            Converters = new[] { new StringEnumConverter() },
+            TypeNameHandling = TypeNameHandling.Auto
+        };
 
         public void Add(TemplateInfo templateInfo)
         {

--- a/src/Common/Default/TemplateInfoRepository.cs
+++ b/src/Common/Default/TemplateInfoRepository.cs
@@ -107,7 +107,7 @@ namespace TextTemplateTransformationFramework.Common.Default
 
         private static string GetFileName() => Path.Combine(GetDirectory(), "templates.config");
 
-        private static string GetDirectory() => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "T4Plus");
+        private static string GetDirectory() => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".t4plus");
 
         private static TemplateInfo FindTemplate(TemplateInfo templateInfo, List<TemplateInfo> templates)
             => templates.Find(x =>

--- a/src/Common/Default/TemplateInfoRepository.cs
+++ b/src/Common/Default/TemplateInfoRepository.cs
@@ -25,6 +25,11 @@ namespace TextTemplateTransformationFramework.Common.Default
 
         public void Add(TemplateInfo templateInfo)
         {
+            if (templateInfo == null)
+            {
+                throw new ArgumentNullException(nameof(templateInfo));
+            }
+
             var templates = GetTemplates().ToList();
 
             var existingTemplate = FindTemplate(templateInfo, templates);
@@ -50,6 +55,11 @@ namespace TextTemplateTransformationFramework.Common.Default
 
         public void Remove(TemplateInfo templateInfo)
         {
+            if (templateInfo == null)
+            {
+                throw new ArgumentNullException(nameof(templateInfo));
+            }
+
             var templates = GetTemplates().ToList();
             var templateToRemove = FindTemplate(templateInfo, templates);
             if (templateToRemove == null)

--- a/src/Common/Default/TemplateInfoRepository.cs
+++ b/src/Common/Default/TemplateInfoRepository.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using TextTemplateTransformationFramework.Common.Contracts;
+
+namespace TextTemplateTransformationFramework.Common.Default
+{
+    public class TemplateInfoRepository : ITemplateInfoRepository
+    {
+        private static readonly JsonSerializerSettings _settings = new() { Converters = new[] { new StringEnumConverter() } };
+
+        public void Add(TemplateInfo templateInfo)
+        {
+            var templates = GetTemplates().ToList();
+
+            var existingTemplate = FindTemplate(templateInfo, templates);
+            if (existingTemplate != null)
+            {
+                throw new ArgumentOutOfRangeException(nameof(templateInfo), "Template already exists");
+            }
+
+            templates.Add(templateInfo);
+            Save(templates);
+        }
+
+        public IEnumerable<TemplateInfo> GetTemplates()
+        {
+            var fileName = GetFileName();
+            if (!File.Exists(fileName))
+            {
+                return Enumerable.Empty<TemplateInfo>();
+            }
+
+            return JsonConvert.DeserializeObject<TemplateInfoConfig>(File.ReadAllText(fileName), _settings).Templates;
+        }
+
+        public void Remove(TemplateInfo templateInfo)
+        {
+            var templates = GetTemplates().ToList();
+            var templateToRemove = FindTemplate(templateInfo, templates);
+            if (templateToRemove == null)
+            {
+                throw new ArgumentOutOfRangeException(nameof(templateInfo), "Template was not found");
+            }
+
+            templates.Remove(templateToRemove);
+            Save(templates);
+        }
+        private static string GetFileName() => Path.Combine(GetDirectory(), "templates.config");
+
+        private static string GetDirectory() => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "T4Plus");
+
+        private static TemplateInfo FindTemplate(TemplateInfo templateInfo, List<TemplateInfo> templates)
+            => templates.Find(x =>
+            x.AssemblyName?.Equals(templateInfo.AssemblyName, StringComparison.OrdinalIgnoreCase) == true
+            && x.ClassName?.Equals(templateInfo.ClassName, StringComparison.OrdinalIgnoreCase) == true
+            && x.FileName?.Equals(templateInfo.FileName, StringComparison.OrdinalIgnoreCase) == true
+            && x.Type == templateInfo.Type);
+
+        private static void Save(List<TemplateInfo> templates)
+        {
+            var directory = GetDirectory();
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+            File.WriteAllText(GetFileName(), JsonConvert.SerializeObject(new TemplateInfoConfig { Templates = templates }, _settings));
+        }
+    }
+
+    public class TemplateInfoConfig
+    {
+        public List<TemplateInfo> Templates { get; set; }
+    }
+}

--- a/src/Common/Default/TemplateInfoRepository.cs
+++ b/src/Common/Default/TemplateInfoRepository.cs
@@ -53,6 +53,30 @@ namespace TextTemplateTransformationFramework.Common.Default
             return JsonConvert.DeserializeObject<TemplateInfoConfig>(_fileContentsProvider.GetFileContents(fileName), _settings).Templates;
         }
 
+        public void Update(TemplateInfo templateInfo)
+        {
+            if (templateInfo == null)
+            {
+                throw new ArgumentNullException(nameof(templateInfo));
+            }
+
+            var templates = GetTemplates().ToList();
+            var index = templates.FindIndex(x =>
+                x.AssemblyName?.Equals(templateInfo.AssemblyName, StringComparison.OrdinalIgnoreCase) == true
+                && x.ClassName?.Equals(templateInfo.ClassName, StringComparison.OrdinalIgnoreCase) == true
+                && x.FileName?.Equals(templateInfo.FileName, StringComparison.OrdinalIgnoreCase) == true
+                && x.Type == templateInfo.Type);
+            if (index == -1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(templateInfo), "Template was not found");
+            }
+
+            templates.RemoveAt(index);
+            templates.Insert(index, templateInfo);
+
+            Save(templates);
+        }
+
         public void Remove(TemplateInfo templateInfo)
         {
             if (templateInfo == null)

--- a/src/Common/Default/TemplateInitializeParameterSetter.cs
+++ b/src/Common/Default/TemplateInitializeParameterSetter.cs
@@ -38,7 +38,7 @@ namespace TextTemplateTransformationFramework.Common.Default
                     info.Property.SetValue(context.TemplateCompilerOutput.Template, info.Attributes.First().Value.ConvertValue(info.Property.PropertyType));
                 }
 
-                if (sessionPropertyValue?.ContainsKey(info.Property.Name) == false)
+                if (sessionPropertyValue != null && !sessionPropertyValue.ContainsKey(info.Property.Name))
                 {
                     sessionPropertyValue.Add(info.Property.Name, info.Attributes.First().Value.ConvertValue(info.Property.PropertyType));
                 }

--- a/src/Common/Extensions/ObjectExtensions.cs
+++ b/src/Common/Extensions/ObjectExtensions.cs
@@ -69,6 +69,11 @@ namespace TextTemplateTransformationFramework.Common.Extensions
 
         public static object ConvertValue(this object instance, Type type)
         {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+            
             if (instance == null)
             {
                 return null;

--- a/src/Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Common/Extensions/ServiceCollectionExtensions.cs
@@ -90,12 +90,12 @@ namespace TextTemplateTransformationFramework.Common.Extensions
         public static IServiceCollection AddTemplateSectionProcessors<TState>(this IServiceCollection instance, Assembly assembly, params Type[] templateSectionProcessorTypesToSkip)
             where TState : class
         {
-            foreach (var type in assembly.GetTemplateSectionProcessorTypes<TState>().Where(t => !templateSectionProcessorTypesToSkip.Any(x => x.FullName.WithoutGenerics() == t.FullName.WithoutGenerics())))
+            foreach (var type in assembly.GetTemplateSectionProcessorTypes<TState>().Where(t => !Array.Exists(templateSectionProcessorTypesToSkip, x => x.FullName.WithoutGenerics() == t.FullName.WithoutGenerics())))
             {
                 instance.AddSingleton(typeof(ITemplateSectionProcessor<TState>), type);
             }
 
-            foreach (var type in assembly.GetTokenMapperTypes().Where(t => !templateSectionProcessorTypesToSkip.Any(x => x.FullName.WithoutGenerics() == t.FullName.WithoutGenerics())))
+            foreach (var type in assembly.GetTokenMapperTypes().Where(t => !Array.Exists(templateSectionProcessorTypesToSkip, x => x.FullName.WithoutGenerics() == t.FullName.WithoutGenerics())))
             {
                 instance.AddSingleton(typeof(ITokenMapperTypeContainer), new TokenMapperTypeContainer(type));
             }

--- a/src/Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Common/Extensions/ServiceCollectionExtensions.cs
@@ -84,7 +84,8 @@ namespace TextTemplateTransformationFramework.Common.Extensions
                 .AddSingleton<IProcessFinalizer<ITextTemplateProcessorContext<TState>>, EmptyProcessFinalizer<ITextTemplateProcessorContext<TState>>>()
                 .AddSingleton<ITemplateProxy, TemplateProxy>()
                 .AddSingleton<ITokenMapperTypeProvider, TokenMapperTypeProvider>()
-                .AddSingleton<IGroupedTokenMapperTypeProvider, GroupedTokenMapperTypeProvider>();
+                .AddSingleton<IGroupedTokenMapperTypeProvider, GroupedTokenMapperTypeProvider>()
+                .AddSingleton<ITemplateInfoRepository, TemplateInfoRepository>();
 
         public static IServiceCollection AddTemplateSectionProcessors<TState>(this IServiceCollection instance, Assembly assembly, params Type[] templateSectionProcessorTypesToSkip)
             where TState : class

--- a/src/Common/FileContentsProviders/FileSystemFileContentsProvider.cs
+++ b/src/Common/FileContentsProviders/FileSystemFileContentsProvider.cs
@@ -1,12 +1,20 @@
-﻿using System.IO;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using TextTemplateTransformationFramework.Common.Contracts;
 
 namespace TextTemplateTransformationFramework.Common.FileContentsProviders
 {
+    [ExcludeFromCodeCoverage]
     public sealed class FileSystemFileContentsProvider : IFileContentsProvider
     {
+        public void CreateDirectory(string directory)
+            => Directory.CreateDirectory(directory);
+
+        public bool DirectoryExists(string directory)
+            => Directory.Exists(directory);
+
         public bool FileExists(string fileName)
-         => File.Exists(fileName);
+            => File.Exists(fileName);
 
         public string GetFileContents(string fileName)
             => File.ReadAllText(fileName);

--- a/src/Common/SectionProcessResult.cs
+++ b/src/Common/SectionProcessResult.cs
@@ -93,6 +93,11 @@ namespace TextTemplateTransformationFramework.Common
         public static SectionProcessResult<TState> Create<TState>(SectionProcessResultData<TState> data)
             where TState : class
         {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
             data.Validate();
 
             //First validate the model...

--- a/src/Common/TemplateInfo.cs
+++ b/src/Common/TemplateInfo.cs
@@ -23,11 +23,5 @@ namespace TextTemplateTransformationFramework.Common
 
         public TemplateInfo Update(string shortName, TemplateParameter[] parameters)
             => new TemplateInfo(shortName, FileName, AssemblyName, ClassName, Type, parameters);
-
-        public static TemplateInfo Text(string shortName, string fileName, TemplateParameter[] parameters)
-            => new TemplateInfo(shortName, fileName, null, null, TemplateType.TextTemplate, parameters);
-
-        public static TemplateInfo Assembly(string shortName, string assemblyName, string className, TemplateParameter[] parameters)
-            => new TemplateInfo(shortName, null, assemblyName, className, TemplateType.AssemblyTemplate, parameters);
     }
 }

--- a/src/Common/TemplateInfo.cs
+++ b/src/Common/TemplateInfo.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace TextTemplateTransformationFramework.Common
+{
+    public record TemplateInfo
+    {
+        public string ShortName { get; }
+        public string FileName { get; }
+        public string AssemblyName { get; }
+        public string ClassName { get; }
+        public TemplateType Type { get; }
+
+        public TemplateInfo(string shortName, string fileName, string assemblyName, string className, TemplateType type)
+        {
+            ShortName = shortName ?? throw new ArgumentNullException(nameof(shortName));
+            FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
+            AssemblyName = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
+            ClassName = className ?? throw new ArgumentNullException(nameof(className));
+            Type = type;
+        }
+
+        public static TemplateInfo Text(string shortName, string fileName)
+            => new TemplateInfo(shortName, fileName, null, null, TemplateType.TextTemplate);
+
+        public static TemplateInfo Assembly(string shortName, string assemblyName, string className)
+            => new TemplateInfo(shortName, null, assemblyName, className, TemplateType.AssemblyTemplate);
+    }
+}

--- a/src/Common/TemplateInfo.cs
+++ b/src/Common/TemplateInfo.cs
@@ -9,20 +9,22 @@ namespace TextTemplateTransformationFramework.Common
         public string AssemblyName { get; }
         public string ClassName { get; }
         public TemplateType Type { get; }
+        public TemplateParameter[] Parameters { get; }
 
-        public TemplateInfo(string shortName, string fileName, string assemblyName, string className, TemplateType type)
+        public TemplateInfo(string shortName, string fileName, string assemblyName, string className, TemplateType type, TemplateParameter[] parameters)
         {
             ShortName = shortName ?? throw new ArgumentNullException(nameof(shortName));
             FileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
             AssemblyName = assemblyName ?? throw new ArgumentNullException(nameof(assemblyName));
             ClassName = className ?? throw new ArgumentNullException(nameof(className));
             Type = type;
+            Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         }
 
-        public static TemplateInfo Text(string shortName, string fileName)
-            => new TemplateInfo(shortName, fileName, null, null, TemplateType.TextTemplate);
+        public static TemplateInfo Text(string shortName, string fileName, TemplateParameter[] parameters)
+            => new TemplateInfo(shortName, fileName, null, null, TemplateType.TextTemplate, parameters);
 
-        public static TemplateInfo Assembly(string shortName, string assemblyName, string className)
-            => new TemplateInfo(shortName, null, assemblyName, className, TemplateType.AssemblyTemplate);
+        public static TemplateInfo Assembly(string shortName, string assemblyName, string className, TemplateParameter[] parameters)
+            => new TemplateInfo(shortName, null, assemblyName, className, TemplateType.AssemblyTemplate, parameters);
     }
 }

--- a/src/Common/TemplateInfo.cs
+++ b/src/Common/TemplateInfo.cs
@@ -21,6 +21,9 @@ namespace TextTemplateTransformationFramework.Common
             Parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         }
 
+        public TemplateInfo Update(string shortName, TemplateParameter[] parameters)
+            => new TemplateInfo(shortName, FileName, AssemblyName, ClassName, Type, parameters);
+
         public static TemplateInfo Text(string shortName, string fileName, TemplateParameter[] parameters)
             => new TemplateInfo(shortName, fileName, null, null, TemplateType.TextTemplate, parameters);
 

--- a/src/Common/TemplateType.cs
+++ b/src/Common/TemplateType.cs
@@ -1,0 +1,8 @@
+﻿namespace TextTemplateTransformationFramework.Common
+{
+    public enum TemplateType
+    {
+        TextTemplate,
+        AssemblyTemplate
+    }
+}

--- a/src/Common/TextTemplateTransformationFramework.Common.csproj
+++ b/src/Common/TextTemplateTransformationFramework.Common.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="pauldeen79.ScriptCompiler.ScriptCompiler" Version="1.1.0" />
   </ItemGroup>
 

--- a/src/Runtime.Tests/CodeGeneration/GenerateCodeTests.cs
+++ b/src/Runtime.Tests/CodeGeneration/GenerateCodeTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using Moq;
+using TextTemplateTransformationFramework.Runtime.CodeGeneration;
+using Xunit;
+
+namespace TextTemplateTransformationFramework.Runtime.Tests;
+
+[ExcludeFromCodeCoverage]
+public class GenerateCodeTests
+{
+    [Fact]
+    public void For_Throws_On_Null_Settings()
+    {
+        this.Invoking(_ => GenerateCode.For(null, new MultipleContentBuilder(), new Mock<ICodeGenerationProvider>().Object))
+            .Should().Throw<ArgumentNullException>().WithParameterName("settings");
+    }
+
+    [Fact]
+    public void For_Should_Not_Throw_On_Null_MultipleContentBuilder()
+    {
+        // Arrange
+        var providerMock = new Mock<ICodeGenerationProvider>();
+        providerMock.Setup(x => x.CreateGenerator()).Returns(new GenerateCodeTests());
+
+        // Act & Assert
+        this.Invoking(_ => GenerateCode.For(new CodeGenerationSettings("UnitTest", true), null, providerMock.Object))
+            .Should().NotThrow<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void For_Throws_On_Null_Provider()
+    {
+        this.Invoking(_ => GenerateCode.For(new CodeGenerationSettings("UnitTest", true), new MultipleContentBuilder(), null))
+            .Should().Throw<ArgumentNullException>().WithParameterName("provider");
+    }
+}

--- a/src/Runtime.Tests/TextTemplateTransformationFramework.Runtime.Tests.csproj
+++ b/src/Runtime.Tests/TextTemplateTransformationFramework.Runtime.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.55" />
     <PackageReference Include="pauldeen79.CrossCutting.Utilities.ObjectDumper" Version="2.7.55" />

--- a/src/Runtime.Tests/TextTemplateTransformationFramework.Runtime.Tests.csproj
+++ b/src/Runtime.Tests/TextTemplateTransformationFramework.Runtime.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.55" />
     <PackageReference Include="pauldeen79.CrossCutting.Utilities.ObjectDumper" Version="2.7.55" />
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Runtime/CodeGeneration/GenerateCode.cs
+++ b/src/Runtime/CodeGeneration/GenerateCode.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 
 namespace TextTemplateTransformationFramework.Runtime.CodeGeneration
 {
@@ -27,6 +28,8 @@ namespace TextTemplateTransformationFramework.Runtime.CodeGeneration
 
         public static GenerateCode For(CodeGenerationSettings settings, IMultipleContentBuilder multipleContentBuilder, ICodeGenerationProvider provider)
         {
+            if (settings == null) throw new ArgumentNullException(nameof(settings));
+            if (provider == null) throw new ArgumentNullException(nameof(provider));
             provider.Initialize(settings.GenerateMultipleFiles, settings.SkipWhenFileExists, settings.BasePath);
             var result = new GenerateCode(provider.BasePath, multipleContentBuilder);
             var generator = provider.CreateGenerator();

--- a/src/Runtime/Extensions/StringExtensions.cs
+++ b/src/Runtime/Extensions/StringExtensions.cs
@@ -6,6 +6,6 @@ namespace TextTemplateTransformationFramework.Runtime.Extensions
     public static class StringExtensions
     {
         public static string NormalizeLineEndings(this string instance)
-            => Regex.Replace(instance, @"\r\n|\n\r|\n|\r", Environment.NewLine);
+            => Regex.Replace(instance, @"\r\n|\n\r|\n|\r", Environment.NewLine, RegexOptions.None, TimeSpan.FromMilliseconds(200));
     }
 }

--- a/src/Runtime/MultipleContentBuilder.cs
+++ b/src/Runtime/MultipleContentBuilder.cs
@@ -67,7 +67,7 @@ namespace TextTemplateTransformationFramework.Runtime
         public void DeleteLastGeneratedFiles(string lastGeneratedFilesPath, bool recurse)
         {
             var basePath = BasePath;
-            if (lastGeneratedFilesPath?.Contains('\\') == true)
+            if (lastGeneratedFilesPath != null && lastGeneratedFilesPath.Contains('\\') == true)
             {
                 var lastSlash = lastGeneratedFilesPath.LastIndexOf("\\");
 

--- a/src/Runtime/MultipleContentBuilder.cs
+++ b/src/Runtime/MultipleContentBuilder.cs
@@ -67,7 +67,7 @@ namespace TextTemplateTransformationFramework.Runtime
         public void DeleteLastGeneratedFiles(string lastGeneratedFilesPath, bool recurse)
         {
             var basePath = BasePath;
-            if (lastGeneratedFilesPath != null && lastGeneratedFilesPath.Contains('\\') == true)
+            if (lastGeneratedFilesPath != null && lastGeneratedFilesPath.Contains('\\'))
             {
                 var lastSlash = lastGeneratedFilesPath.LastIndexOf("\\");
 

--- a/src/T4.Plus.Tests/TestFixtures/FileContentsProviderMock.cs
+++ b/src/T4.Plus.Tests/TestFixtures/FileContentsProviderMock.cs
@@ -9,6 +9,16 @@ namespace TextTemplateTransformationFramework.T4.Plus.Tests.TestFixtures
     {
         public Func<string, string> GetFileContentsDelegate { get; set; }
 
+        public void CreateDirectory(string directory)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool DirectoryExists(string directory)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool FileExists(string fileName)
         {
             throw new NotImplementedException();

--- a/src/T4.Plus.Tests/TextTemplateTransformationFramework.T4.Plus.Tests.csproj
+++ b/src/T4.Plus.Tests/TextTemplateTransformationFramework.T4.Plus.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.55" />
     <PackageReference Include="pauldeen79.CrossCutting.Utilities.ObjectDumper" Version="2.7.55" />

--- a/src/T4.Plus.Tests/TextTemplateTransformationFramework.T4.Plus.Tests.csproj
+++ b/src/T4.Plus.Tests/TextTemplateTransformationFramework.T4.Plus.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.55" />
     <PackageReference Include="pauldeen79.CrossCutting.Utilities.ObjectDumper" Version="2.7.55" />
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/T4.Tests/IntegrationTests.cs
+++ b/src/T4.Tests/IntegrationTests.cs
@@ -570,6 +570,16 @@ Hello <#= ""world"" #><# Write(""!""); #>";
         [ExcludeFromCodeCoverage]
         private sealed class FileContentsProviderMock : IFileContentsProvider
         {
+            public void CreateDirectory(string directory)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool DirectoryExists(string directory)
+            {
+                throw new NotImplementedException();
+            }
+
             public bool FileExists(string fileName)
             {
                 throw new NotImplementedException();

--- a/src/T4.Tests/TestFixtures/FileContentsProviderMock.cs
+++ b/src/T4.Tests/TestFixtures/FileContentsProviderMock.cs
@@ -9,6 +9,16 @@ namespace TextTemplateTransformationFramework.T4.Tests.TestFixtures
     {
         public Func<string, string> GetFileContentsDelegate { get; set; }
 
+        public void CreateDirectory(string directory)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool DirectoryExists(string directory)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool FileExists(string fileName)
         {
             throw new NotImplementedException();

--- a/src/T4.Tests/TextTemplateTransformationFramework.T4.Tests.csproj
+++ b/src/T4.Tests/TextTemplateTransformationFramework.T4.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.55" />
     <PackageReference Include="xunit" Version="2.4.2" />
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/T4.Tests/TextTemplateTransformationFramework.T4.Tests.csproj
+++ b/src/T4.Tests/TextTemplateTransformationFramework.T4.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="pauldeen79.CrossCutting.Common.Testing" Version="2.7.55" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/Utilities.Tests/Utilities.Tests.csproj
+++ b/src/Utilities.Tests/Utilities.Tests.csproj
@@ -9,7 +9,7 @@
   
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Utilities.Tests/Utilities.Tests.csproj
+++ b/src/Utilities.Tests/Utilities.Tests.csproj
@@ -9,7 +9,7 @@
   
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
You can now store information about templates on your system in a global place (your user directory), and run templates from anywhere on your system by the template's short name.