### PR TITLE
Fixed code generation assembly without full paths and -u option

### DIFF
--- a/src/Runtime/CodeGeneration/CodeGenerationAssembly.cs
+++ b/src/Runtime/CodeGeneration/CodeGenerationAssembly.cs
@@ -74,7 +74,7 @@ namespace TextTemplateTransformationFramework.Runtime.CodeGeneration
                 var assemblyName = _assemblyName;
                 if (assemblyName.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase) && !Path.IsPathRooted(assemblyName))
                 {
-                    assemblyName = Path.Combine(!string.IsNullOrEmpty(_currentDirectory) ? _currentDirectory : Directory.GetCurrentDirectory(), assemblyName);
+                    assemblyName = Path.Combine(_currentDirectory, Path.GetFileName(assemblyName));
                 }
                 return context.LoadFromAssemblyPath(assemblyName);
             }


### PR DESCRIPTION
See title. The 'assembly' command was broken in some circumstances. This PR fixes this.

See the ExpressionFramework build for example. Assemblies could not be located...